### PR TITLE
Aggregate functions in Having clauses

### DIFF
--- a/gdms/src/main/scala/org/gdms/sql/engine/commands/FilterCommand.scala
+++ b/gdms/src/main/scala/org/gdms/sql/engine/commands/FilterCommand.scala
@@ -73,11 +73,12 @@ class ExpressionFilterCommand(e: Expression) extends FilterCommand with Expressi
   protected def filterExecute: Row => Boolean = { e.evaluate(_).getAsBoolean.booleanValue }
   
   override def doPrepare {
-    // no aggregate function is allowed in a WHERE / HAVING clause
+    // no aggregate function is allowed in a WHERE clause
     // this check cannot be done in Filter Operation because aggregates are resolved later.
+    // HAVING clauses are handled during the function step (aggregates are allowed in these)
     def check (ex: Expression) {
       ex match {
-        case agg(f,_) => throw new SemanticException("No aggregate function is allowed in a WHERE / HAVING clause."
+        case agg(f,_) => throw new SemanticException("No aggregate function is allowed in a WHERE clause."
                                                      + " Found function '" + f.getName + "'.")
         case _ => ex.children map check
       }

--- a/gdms/src/main/scala/org/gdms/sql/engine/operations/Operation.scala
+++ b/gdms/src/main/scala/org/gdms/sql/engine/operations/Operation.scala
@@ -325,7 +325,7 @@ extends Operation with ExpressionOperation {
  * @author Antoine Gourlay
  * @since 0.1
  */
-case class Aggregate(exp: List[(Expression, Option[String])],var child: Operation) 
+case class Aggregate(var exp: List[(Expression, Option[String])],var child: Operation) 
 extends Operation with ExpressionOperation {
   def children = List(child)
   override def children_=(o: List[Operation]) = {o.headOption.map(child = _)}

--- a/gdms/src/test/java/org/gdms/sql/strategies/SQLTest.java
+++ b/gdms/src/test/java/org/gdms/sql/strategies/SQLTest.java
@@ -994,6 +994,7 @@ public class SQLTest extends TestBase {
         
         @Test
         public void testHavingDirectAggregate() throws Exception {
+                dsf.getProperties().setProperty("output.explain", "true");
                 dsf.getSourceManager().register("groupcsv",
                         new File(TestResourceHandler.TESTRESOURCES, "groupby.csv"));
                 DataSource ds = dsf.getDataSourceFromSQL("SELECT country"
@@ -1001,6 +1002,18 @@ public class SQLTest extends TestBase {
                         + " ORDER BY country;");
                 ds.open();
                 assertEquals(ds.getRowCount(), 3);
+                ds.close();
+        }
+        
+        @Test
+        public void testHavingDirectAggregateNoGroupBy() throws Exception {
+                dsf.getProperties().setProperty("output.explain", "true");
+                dsf.getSourceManager().register("groupcsv",
+                        new File(TestResourceHandler.TESTRESOURCES, "groupby.csv"));
+                DataSource ds = dsf.getDataSourceFromSQL("SELECT 1"
+                        + " FROM groupcsv HAVING Sum(id :: double) >= 8;");
+                ds.open();
+                assertEquals(1, ds.getRowCount());
                 ds.close();
         }
 


### PR DESCRIPTION
This adds support for aggregate functions in SQL HAVING clauses.

The usual syntax like this is supported:

``` sql
SELECT field FROM myTable GROUP BY field HAVING sum(otherField) < 18;
```

I chose here to stick to PostgreSQL 'standard' behavior when there is no GROUP BY clause, only a HAVING clause. There are two ways to interpret this kind of query:
- in PostgreSQL, the whole table is a group, you can only reference fields inside aggregate functions. Thus the following query returns either one or zero rows depending on the number of lines in the table:

``` sql
SELECT 1 FROM myTable HAVING count(*) >= 10;
```
- In some other dialects, like T-SQL, there is a much more powerful behavior: the aggregate is evaluated on the whole table but HAVING still processes individual rows. Thus the following keeps all rows whose value is below the average of the whole table:

``` sql
SELECT * FROM myTable HAVING myField < avg(myField);
```

@ebocher, @gpetit: I only implemented the first possibility here, but do you think the second one might be better?

Note: the two options are mutually exclusive.
