### PR TITLE
Knowing if an URI is registred in GDMS

### DIFF
--- a/gdms/src/main/java/org/gdms/data/DataSourceDefinition.java
+++ b/gdms/src/main/java/org/gdms/data/DataSourceDefinition.java
@@ -46,6 +46,7 @@ import org.gdms.source.directory.DefinitionType;
 
 /**
  * Class to be implemented to add new types of sources to the system.
+ * @param <D> the driver type this definition depends on
  */
 public interface DataSourceDefinition<D extends Driver> {
 
@@ -171,6 +172,7 @@ public interface DataSourceDefinition<D extends Driver> {
 
         /**
          * Deletes all physical storage associated with this source.
+         * @throws DriverException 
          */
         void delete() throws DriverException;
 
@@ -184,6 +186,7 @@ public interface DataSourceDefinition<D extends Driver> {
 
         /**
          * Gets an URI representing this definition.
+         * @return an URI representing this definition (or null if impossible) 
          * @throws DriverException 
          */
         URI getURI() throws DriverException;

--- a/gdms/src/main/java/org/gdms/source/DefaultSourceManager.java
+++ b/gdms/src/main/java/org/gdms/source/DefaultSourceManager.java
@@ -1255,4 +1255,36 @@ public final class DefaultSourceManager implements SourceManager {
                         throw new NoSuchTableException(name);
                 }
         }
+
+        @Override
+        public boolean exists(URI uri) {
+                for (ExtendedSource e : nameSource.values()) {
+                        try {
+                                if (uri.equals(e.getURI())) {
+                                        return true;
+                                }
+                        } catch (DriverException ex) {
+                                LOG.warn("Problem while retriving URI for '" + e.getName()
+                                        + "'. Ignoring.", ex);
+                        }
+                }
+
+                return false;
+        }
+
+        @Override
+        public String getNameFor(URI uri) throws NoSuchTableException {
+                for (ExtendedSource e : nameSource.values()) {
+                        try {
+                                if (uri.equals(e.getURI())) {
+                                        return e.getName();
+                                }
+                        } catch (DriverException ex) {
+                                LOG.warn("Problem while retriving URI for '" + e.getName()
+                                        + "'. Ignoring.", ex);
+                        }
+                }
+
+                throw new NoSuchTableException("for '" + uri.toString() + "'");
+        }
 }

--- a/gdms/src/main/java/org/gdms/source/SourceManager.java
+++ b/gdms/src/main/java/org/gdms/source/SourceManager.java
@@ -341,12 +341,29 @@ public interface SourceManager {
         void rename(String dsName, String newName);
 
         /**
-         * Checks if there is a some with a specific name.
+         * Checks if there is a source with a specific name.
          *
          * @param sourceName a name/alias
          * @return true if there is a source with the specified name, false otherwise
          */
         boolean exists(String sourceName);
+        
+        /**
+         * Checks if a source with the specified URI is already registered.
+         *
+         * @param uri a valid URI
+         * @return true if there is a source with the specified URI, false otherwise
+         */
+        boolean exists(URI uri);
+        
+        /**
+         * Gets the main name of the source.
+         *
+         * @param uri a valid URI
+         * @return the (main) name of the source with the specified URI
+         * @throws NoSuchTableException if there is no source with the specified URI
+         */
+        String getNameFor(URI uri) throws NoSuchTableException;
 
         /**
          * Gets the main name of the source.

--- a/gdms/src/test/java/org/gdms/source/SourceManagementTest.java
+++ b/gdms/src/test/java/org/gdms/source/SourceManagementTest.java
@@ -52,6 +52,7 @@ import org.gdms.TestBase;
 import org.gdms.TestResourceHandler;
 import org.gdms.data.DataSource;
 import org.gdms.data.DataSourceFactory;
+import org.gdms.data.NoSuchTableException;
 import org.gdms.data.SourceAlreadyExistsException;
 import org.gdms.data.db.DBSource;
 import org.gdms.data.edition.FakeDBTableSourceDefinition;
@@ -646,6 +647,24 @@ public class SourceManagementTest extends TestBase {
                 assertEquals("tata", s.getSchemaName());
                 assertEquals("me", s.getUser());
                 assertEquals("changeme", s.getPassword());
+        }
+        
+        @Test
+        public void testURIManagement() throws Exception {
+                URI uri = testFile.toURI();
+                assertFalse(sm.exists(uri));
+                
+                try {
+                        sm.getNameFor(uri);
+                        fail();
+                } catch (NoSuchTableException e) {
+                        // should fail
+                }
+                
+                sm.register("test", uri);
+                assertTrue(sm.exists(uri));
+                
+                assertEquals("test", sm.getNameFor(uri));
         }
 
         private void testListenCommits(DataSource ds) throws DriverException {


### PR DESCRIPTION
Currently there is a function named SourceManager.nameAndRegister(URI uri);

But if the URI has already been registered then an error is thrown :

```
56 [AWT-EventQueue-0] ERROR org.orbisgis.core.layerModel.OwsMapContext  - The layer has not been imported
org.orbisgis.core.layerModel.LayerException: Unable to load the data source uri file:/home/user/geocatalog/nantes_centre_lden2008_vl_pl/2002_result/contouring_noise_map.shp.
    at org.orbisgis.core.layerModel.OwsMapContext.parseJaxbLayer(OwsMapContext.java:510)
    at org.orbisgis.core.layerModel.OwsMapContext.loadOwsContext(OwsMapContext.java:564)
    at org.orbisgis.core.layerModel.OwsMapContext.open(OwsMapContext.java:586)
    at org.orbisgis.view.map.MapElement.open(MapElement.java:105)
    at org.orbisgis.view.main.Core$ReadMapContextProcess.run(Core.java:312)
    at org.orbisgis.view.background.Job.run(Job.java:69)
    at org.orbisgis.view.background.RunnableBackgroundJob.run(RunnableBackgroundJob.java:68)
    at java.lang.Thread.run(Thread.java:662)
    at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:209)
    at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:641)
    at java.awt.EventQueue.access$000(EventQueue.java:84)
    at java.awt.EventQueue$1.run(EventQueue.java:602)
    at java.awt.EventQueue$1.run(EventQueue.java:600)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.security.AccessControlContext$1.doIntersectionPrivilege(AccessControlContext.java:87)
    at java.awt.EventQueue.dispatchEvent(EventQueue.java:611)
    at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:269)
    at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:184)
    at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:174)
    at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:169)
    at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:161)
    at java.awt.EventDispatchThread.run(EventDispatchThread.java:122)
Caused by: org.gdms.data.DataSourceCreationException: org.gdms.data.SourceAlreadyExistsException: The source already exists with the name: contouring_noise_map
    at org.orbisgis.core.layerModel.OwsMapContext.registerLayerResource(OwsMapContext.java:483)
    at org.orbisgis.core.layerModel.OwsMapContext.parseJaxbLayer(OwsMapContext.java:506)
    ... 21 more
Caused by: org.gdms.data.SourceAlreadyExistsException: The source already exists with the name: contouring_noise_map
    at org.gdms.source.DefaultSourceManager.register(DefaultSourceManager.java:528)
    at org.gdms.source.DefaultSourceManager.register(DefaultSourceManager.java:519)
    at org.gdms.source.DefaultSourceManager.registerURI(DefaultSourceManager.java:429)
    at org.gdms.source.DefaultSourceManager.nameAndRegister(DefaultSourceManager.java:661)
    at org.orbisgis.core.layerModel.OwsMapContext.registerLayerResource(OwsMapContext.java:481)
    ... 22 more
```

The map context needs two functionality in gdms
- Test if the URI has already been registered
- Get the source name of the already registered URI
