### PR TITLE
Only add the default style if necessary + prevents the list of styles of being reset

### DIFF
--- a/orbisgis-core/src/main/java/org/orbisgis/core/layerModel/BeanLayer.java
+++ b/orbisgis-core/src/main/java/org/orbisgis/core/layerModel/BeanLayer.java
@@ -62,7 +62,7 @@ public abstract class BeanLayer extends AbstractLayer {
 
         //bean properties
         private Description description;
-        private List<Style> styleList;
+        private List<Style> styleList = new ArrayList<Style>();
         private boolean visible = true;
         
         public BeanLayer(String name) {
@@ -231,14 +231,6 @@ public abstract class BeanLayer extends AbstractLayer {
                         fireNameChanged();
                 }
 	}
-       
-        /**
-         * Initialize the list of styles, letting it empty and not notifying the
-         * listeners.
-         */
-        protected final void initStyles(){
-                styleList = new ArrayList<Style>();
-        }
         
     @Override
     public List<Style> getStyles() {

--- a/orbisgis-core/src/main/java/org/orbisgis/core/layerModel/Layer.java
+++ b/orbisgis-core/src/main/java/org/orbisgis/core/layerModel/Layer.java
@@ -155,9 +155,11 @@ public class Layer extends BeanLayer {
 	public void open() throws LayerException {
 		try {
 			dataSource.open();
-                        initStyles();
-                        Style s = new Style(this, true);
-                        getStyles().add(s);
+                        if (getStyles().isEmpty()) {
+                                // special case: no style were ever set
+                                // let's go for a default style
+                                getStyles().add(new Style(this, true));
+                        }
 			// Create a legend for each spatial field
 			Metadata metadata = dataSource.getMetadata();
 			for (int i = 0; i < metadata.getFieldCount(); i++) {


### PR DESCRIPTION
This prevents the list of styles of a layer to be reset when open() is called. 

Any style added before will still be there, and the default style is only added if the list is empty.

I think the diff is pretty straightforward.

Review by @agueganno, @nicolas-f please :-)
