### PR TITLE
Fix map context test failures

### DIFF
--- a/orbisgis-core/src/main/java/org/orbisgis/core/layerModel/OwsMapContext.java
+++ b/orbisgis-core/src/main/java/org/orbisgis/core/layerModel/OwsMapContext.java
@@ -497,7 +497,7 @@ public final class OwsMapContext extends BeanMapContext {
          */
         private void parseJaxbLayer(LayerType lt,ILayer parentLayer) throws LayerException {
                 //Test if lt is a group
-                if(!lt.getLayer().isEmpty() || (lt.getStyleList()==null && lt.getDataURL()==null )) {
+                if(!lt.getLayer().isEmpty() || (lt.getDataURL()==null )) {
                         //it will create a LayerCollection
                         parseJaxbLayerCollection(lt,parentLayer);
                 }else{

--- a/orbisgis-core/src/test/java/org/orbisgis/core/MapContextTest.java
+++ b/orbisgis-core/src/test/java/org/orbisgis/core/MapContextTest.java
@@ -40,8 +40,10 @@ package org.orbisgis.core;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Envelope;
 import java.awt.GraphicsEnvironment;
-import java.io.*;
-import net.opengis.ows_context.OWSContextType;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
 import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Test;
@@ -53,7 +55,6 @@ import org.orbisgis.core.map.export.MapExportManager;
 import org.orbisgis.progress.NullProgressMonitor;
 import org.orbisgis.utils.FileUtils;
 
-@Deprecated
 public class MapContextTest extends AbstractTest {
 
 	@Override


### PR DESCRIPTION
There were three broken tests in monomap. That should fix them.
