### PR TITLE
Change the rendering strategy.

### DIFF
--- a/orbisgis-core/src/main/java/org/orbisgis/core/renderer/ImageRenderer.java
+++ b/orbisgis-core/src/main/java/org/orbisgis/core/renderer/ImageRenderer.java
@@ -40,9 +40,7 @@ package org.orbisgis.core.renderer;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import org.gdms.data.DataSource;
 import org.orbisgis.core.map.MapTransform;
 import org.orbisgis.core.renderer.se.Symbolizer;
@@ -54,37 +52,28 @@ import org.orbisgis.core.renderer.se.Symbolizer;
 public class ImageRenderer extends Renderer {
 
     private List<BufferedImage> imgSymbs = null;
-    private Map<Integer, Graphics2D> g2Level = null;
+    private List<Symbolizer> symbols = null;
+    private List<Graphics2D> graphics = null;
 
     @Override
     protected void initGraphics2D(List<Symbolizer> symbs, Graphics2D g2, MapTransform mt) {
         imgSymbs = new ArrayList<BufferedImage>();
-        
-        g2Level = new HashMap<Integer, Graphics2D>();
-
+        symbols = symbs;
+        graphics = new ArrayList<Graphics2D>();
         /**
-         * Create one buffered image for each level present in the style. This way allows
+         * Create one buffered image for each Symbolizer present in the style. This way allows
          * to render all symbolizer in one pass without encountering layer level issues
          */
         for (Symbolizer s : symbs) {
-
-            Graphics2D sG2;
-            // Does the level of the current symbolizer already have a graphic2s ?
-            if (!g2Level.containsKey(s.getLevel())){
-                // It's a new level => create a new graphics2D
-                BufferedImage bufImg = new BufferedImage(mt.getWidth(), mt.getHeight(), BufferedImage.TYPE_INT_ARGB);
-                sG2 = bufImg.createGraphics();
-                sG2.addRenderingHints(mt.getRenderingHints());
-                imgSymbs.add(bufImg);
-                // Map the graphics with its level
-                g2Level.put(s.getLevel(), sG2);
-            }
+            BufferedImage bufImg = new BufferedImage(mt.getWidth(), mt.getHeight(), BufferedImage.TYPE_INT_ARGB);
+            graphics.add(bufImg.createGraphics());
+            imgSymbs.add(bufImg);
         }
     }
 
     @Override
     protected Graphics2D getGraphics2D(Symbolizer s) {
-        return g2Level.get(s.getLevel());
+        return graphics.get(symbols.indexOf(s));
     }
 
 
@@ -94,13 +83,10 @@ public class ImageRenderer extends Renderer {
 
     @Override
     protected void disposeLayer(Graphics2D g2) {
-        for (Integer key : g2Level.keySet()){
-            Graphics2D get = g2Level.get(key);
+        for (Graphics2D get : graphics){
             get.dispose();
         }
-
-        g2Level.clear();
-        
+        graphics.clear();
         for (BufferedImage img : imgSymbs) {
             g2.drawImage(img, null, null);
         }

--- a/orbisgis-core/src/main/java/org/orbisgis/core/renderer/Renderer.java
+++ b/orbisgis-core/src/main/java/org/orbisgis/core/renderer/Renderer.java
@@ -55,7 +55,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.logging.Level;
 import javax.imageio.ImageIO;
 import org.apache.log4j.Logger;
 import org.gdms.data.DataSource;
@@ -95,7 +94,7 @@ public abstract class Renderer {
         private final static Logger LOGGER = Logger.getLogger(Renderer.class);
         private final static I18n I18N = I18nFactory.getI18n(Renderer.class);
         /**
-         * This method shall returns a graphics2D for each symbolisers in the list.
+         * This method shall returns a graphics2D for each symbolizers in the list.
          * This is useful to make the diff bw pdf purpose and image purpose
          * Is called just before a new layer is drawn
          * @return
@@ -105,6 +104,12 @@ public abstract class Renderer {
         protected abstract void initGraphics2D(List<Symbolizer> symbs, Graphics2D g2,
                 MapTransform mt);
 
+        /**
+         * Gets the {@code Graphics2D} instance that is associated to the {@code
+         * Symbolizer s}.
+         * @param s
+         * @return
+         */
         protected abstract Graphics2D getGraphics2D(Symbolizer s);
 
         protected abstract void releaseGraphics2D(Graphics2D g2);
@@ -316,11 +321,9 @@ public abstract class Renderer {
         }
 
         private static void printEx(Exception ex, ILayer layer, Graphics2D g2) {
-                java.util.logging.Logger.getLogger("Could not draw " +
-                        layer.getName()).log(Level.SEVERE, "Error while drawing " + layer.getName(), ex);
-                ex.printStackTrace(System.err);
-                g2.setColor(Color.red);
-                g2.drawString(ex.toString(), EXECP_POS, EXECP_POS);
+                LOGGER.warn("Could not draw " +layer.getName(), ex);
+//                g2.setColor(Color.red);
+//                g2.drawString(ex.toString(), EXECP_POS, EXECP_POS);
         }
 
         public void draw(Graphics2D g2dMap, int width, int height,

--- a/orbisgis-core/src/main/java/org/orbisgis/core/renderer/se/Style.java
+++ b/orbisgis-core/src/main/java/org/orbisgis/core/renderer/se/Style.java
@@ -267,8 +267,6 @@ public final class Style implements SymbolizerNode {
                 }
             }
         }
-
-        Collections.sort(layerSymbolizers);
     }
 
     public void resetSymbolizerLevels() {


### PR DESCRIPTION
Levels are not in use anymore. From now on, we draw symbolizers in the order they
are found in the rules. We currently simply use indices of the generated
list of symbolizers (which is not sorted anymore in Style). It should be
enough : this list is generated each time the time is rendered.

This should fix issue #58
