### PR TITLE
Fix/drop geocatalog

### DIFF
--- a/orbisgis-view/src/main/java/org/orbisgis/view/geocatalog/Catalog.java
+++ b/orbisgis-view/src/main/java/org/orbisgis/view/geocatalog/Catalog.java
@@ -177,7 +177,7 @@ public class Catalog extends JPanel implements DockingPanel {
         public void onDropURI(List<URI> uriDrop) {
                 SourceManager src = getDataManager().getSourceManager();
                 for(URI uri : uriDrop) {
-                        // Use the file name as 
+                        // Use the file name as the data source name
                         if(uri.getScheme().equals("file")) {
                                 File file = new File(uri);
                                 src.register(src.getUniqueName(FileUtils.getFileNameWithoutExtensionU(file)),uri);


### PR DESCRIPTION
Use the file name for the data source name. Currently providing only a URI to the source manager always generate a random data source name.
