### PR TITLE
Fix an error in OrbiSGIS initialization.

### DIFF
--- a/orbisgis-core/src/main/java/org/orbisgis/core/layerModel/BeanMapContext.java
+++ b/orbisgis-core/src/main/java/org/orbisgis/core/layerModel/BeanMapContext.java
@@ -174,7 +174,7 @@ public abstract class BeanMapContext implements MapContext {
          */
         @Override
         public void setBoundingBox(Envelope boundingBox) {
-                if (!boundingBox.equals(this.boundingBox)) {
+                if (boundingBox != null && !boundingBox.equals(this.boundingBox)) {
                         Envelope oldBoundingBox = this.boundingBox;
                         this.boundingBox = boundingBox;
                         propertyChangeSupport.firePropertyChange(PROP_BOUNDINGBOX, oldBoundingBox, boundingBox);


### PR DESCRIPTION
Bug : during the first startup, we build an interface with an empty map,
toc and geocatalog. While building them, we make a first draw of the
(empty) map.

The MapControl.Drawer class calls setBoundingBox on the BeanMapContext
describing the map. It retrieves the adjusted extent of the MapTransform
to do it. At this stage, both the adjusted extend and the bounding box
are null... That leads to an unexpected, unwanted NPE.

Fix : There could be many ways to fix this problem... I've chosen the fastest,
that may not be the best. I just check that we don't send a null
Envelope to the BeanMapContext. I find it coherent, and better than an
arbitrary value at startup.
