### PR TITLE
Remove reference to WarningListener

### DIFF
--- a/orbisgis-core/src/main/java/org/orbisgis/core/beanshell/BeanshellScript.java
+++ b/orbisgis-core/src/main/java/org/orbisgis/core/beanshell/BeanshellScript.java
@@ -34,7 +34,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import org.gdms.data.DataSourceFactory;
-import org.gdms.data.WarningListener;
 import org.orbisgis.core.DataManager;
 import org.orbisgis.core.DefaultDataManager;
 import org.orbisgis.core.Services;
@@ -66,21 +65,6 @@ public class BeanshellScript {
 
                 //Register the datasource
                 DataSourceFactory dsf = new DataSourceFactory();
-
-                // Pipeline the warnings in gdms to the warning system in the
-                // application
-                dsf.setWarninglistener(new WarningListener() {
-
-                        @Override
-                        public void throwWarning(String msg) {
-                                System.out.println(msg);
-                        }
-
-                        @Override
-                        public void throwWarning(String msg, Throwable t, Object source) {
-                                System.out.println(msg);
-                        }
-                });
 
                 dsf.loadPlugins();
 


### PR DESCRIPTION
The `Warning Listener` is an old deprecated feature of Gdms from the time OrbisGIS did not use log4j.

This removes any dependency to it from the `feature/monomap` branch, so that I can finally remove it from Gdms (and the OrbisGIS from `master`) later.

Within Gdms, everything that used it will use log4j's `LOG.warn`, so these warnings are not lost.
