### PR TITLE
scala incremental compilation with maven

### DIFF
--- a/gdms/pom.xml
+++ b/gdms/pom.xml
@@ -126,7 +126,7 @@
                         <plugin>
                                 <groupId>net.alchim31.maven</groupId>
                                 <artifactId>scala-maven-plugin</artifactId>
-                                <version>3.0.2</version>
+                                <version>3.1.0</version>
                                 <executions>
                                         <execution>
                                                 <id>scala-compile-first</id>
@@ -213,6 +213,39 @@
                 </plugins>
         </build>
         <profiles>
+                <profile>
+                        <id>incremental</id>
+                        <build>
+                                <plugins>
+                                        <plugin>
+                                                <groupId>net.alchim31.maven</groupId>
+                                                <artifactId>scala-maven-plugin</artifactId>
+                                                <version>3.1.0</version>
+                                                <executions>
+                                                        <execution>
+                                                                <id>scala-compile-first</id>
+                                                                <phase>process-resources</phase>
+                                                                <goals>
+                                                                        <goal>add-source</goal>
+                                                                        <goal>compile</goal>
+                                                                </goals>
+                                                        </execution>									
+                                                        <execution>
+                                                                <id>scala-test-compile</id>
+                                                                <phase>process-test-resources</phase>
+                                                                <goals>
+                                                                        <goal>testCompile</goal>
+                                                                </goals>
+                                                        </execution>
+                                                </executions>
+                                                <configuration>
+                                                        <recompileMode>incremental</recompileMode>
+                                                        <useZincServer>true</useZincServer>
+                                                </configuration>
+                                        </plugin>
+                                </plugins>
+                        </build>
+                </profile>
                 <profile>
                         <id>coverage</id>
                         <repositories>


### PR DESCRIPTION
This bumps the scala-maven-plugin and adds a profile for incremental compilation using [zinc](https://github.com/typesafehub/zinc#readme).

It basically gives us real incremental compilation (from the SBT incremental compilation), and if there is a local zinc server, this basically uses it as a resident compiler (even more win).

The need to clean/install before running a test from Netbeans is completely gone :-D
This was already possible with running SBT and maven in parallel (+ the Ant used by Netbeans to run the test...), but it way hacky and failed quite often.
