### PR TITLE
Interproject javadoc links + allow link to source in the generated javadoc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/nbactions.xml
 nbactions.xml
 
+/target/

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
                                 <version>2.8.1</version>
                                 <configuration>
                                         <detectOfflineLinks>false</detectOfflineLinks>
+                                        <linksource>true</linksource>
                                         <offlineLinks>
                                                 <offlineLink>
                                                         <url>http://javadoc.orbisgis.org/latest/gdms-2.0-SNAPSHOT</url>
@@ -95,6 +96,10 @@
                                                         <location>${basedir}/../orbisgis-core/target/site/apidocs/</location>
                                                 </offlineLink>
                                         </offlineLinks>
+                                        <links>
+                                               <link>http://javadoc.orbisgis.org/latest/commons-1.4-SNAPSHOT/</link> 
+                                               <link>http://javadoc.orbisgis.org/latest/grap-1.4.3-SNAPSHOT/</link> 
+                                        </links>
                                 </configuration>
                         </plugin>
                 </plugins>

--- a/tools/build-javadoc-links
+++ b/tools/build-javadoc-links
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+#
+# Utility to add javadoc links to the online (GitHub) source
+# Must be run from the root of the git repository, after generating the javadoc for any/all the modules
+
+# parameter, if exist, is the revision to display (git revision or branche name)
+# defaults to master
+if [ $# == 0 ]
+then
+  rev="master"
+else
+  rev="$1"
+fi
+
+url=$(echo "https://github.com/irstv/orbisgis/tree/${rev}/gdms/src/main/java" | sed 's/\//\\\//g')
+
+rm -rf */target/site/apidocs/src-html
+files=$(find */target/site/apidocs/ -name "*.html" -type f)
+
+sed -i "s/\(\\.\\.\/\)\+src-html\(.*\).html#line\.\([0-9]\+\)\">/${url}\2.java#L\3\" target=\"_blank\"/g" ${files}


### PR DESCRIPTION
Inter-module javadoc links were gone when we migrated to GitHub. This fixes that.

This also activates the link-to-source option in javadoc, with some bash trickery to turn that into links to the specific online revision on GitHub.

Browsing the javadoc or gdms is almost useful now :-)
