### PR TITLE
Buttons not refreshed in the simple legend editor.

### DIFF
--- a/orbisgis-view/src/main/java/org/orbisgis/view/toc/actions/cui/LegendTree.java
+++ b/orbisgis-view/src/main/java/org/orbisgis/view/toc/actions/cui/LegendTree.java
@@ -136,6 +136,7 @@ public class LegendTree extends JPanel {
                         tm.removeElement(tm.getRoot(), select);
                         legendsPanel.refreshLegendContainer();
                 }
+                refreshIcons();
         }
 
         /**
@@ -154,6 +155,7 @@ public class LegendTree extends JPanel {
                                 addLegend();
                         }
                 }
+                refreshIcons();
         }
 
         /**


### PR DESCRIPTION
When adding a second legend in a Rule, in the simple legend editor, the buttons used to manage the legends werenot correctly refreshed. This commit fixes that.
