### PR TITLE
It seems there was a typo in the PostgreSQL driver. We were expecting a

### DIFF
--- a/gdms/src/main/java/org/gdms/driver/postgresql/PostgreSQLDriver.java
+++ b/gdms/src/main/java/org/gdms/driver/postgresql/PostgreSQLDriver.java
@@ -140,7 +140,7 @@ public final class PostgreSQLDriver extends DefaultDBDriver {
                 Connection c;
                 if (connString.toLowerCase().contains("ssl=true")) {
                         Properties props = new Properties();
-                        props.setProperty("sslfactory", "org.postgresql.ssl.NonValidationFactory");
+                        props.setProperty("sslfactory", "org.postgresql.ssl.NonValidatingFactory");
                         c = DriverManager.getConnection(connString, props);
 
                 } else {


### PR DESCRIPTION
class named NonValidationFactory. It seems to be named
NonValidatingFactory. It compiled anyway as the class was supposed to be
found thanks to reflection made by the JVM.
