### PR TITLE
Because of the recent changes in the management of maps, there were some

### DIFF
--- a/orbisgis-view/src/main/java/org/orbisgis/view/map/MapControl.java
+++ b/orbisgis-view/src/main/java/org/orbisgis/view/map/MapControl.java
@@ -447,16 +447,27 @@ public class MapControl extends JComponent implements ContainerListener {
 		public void layerAdded(LayerCollectionEvent listener) {
 			for (ILayer layer : listener.getAffected()) {
 				addLayerListenerRecursively(layer, this);
-				if (mapTransform.getExtent() == null || mapTransform.getExtent().isNull()) {
+                                ILayer[] model = getMapContext().getLayers();
+                                int count = 0;
+                                //We check that we have only one spatial layer in
+                                //the layer model. It it is the case, we will :
+                                // - set adjustExtent to true in the MapTransform
+                                // - set the extent of the map to the extent of the layer.
+                                for(int i=0; i<model.length && count <2;i++){
+                                        if(model[i] instanceof Layer){
+                                                count++;
+                                        }
+                                }
+				if (count == 1) {
 					final Envelope e = layer.getEnvelope();
 					if (e != null) {
                                                 mapTransform.setAdjustExtent(true);
 						mapTransform.setExtent(e);
 					}
 				} else {
-                			invalidateImage();
-				}
-			}
+                                        invalidateImage();
+                                }
+                        }
 		}
 
                 @Override


### PR DESCRIPTION
misbehaviours in the MapControl.

Until now, when removing the last spatial layer, we put a null extent
in the map control and set adjustExtent to null in order to be able to
zoom again to the right place when adding a new layer. This had some
unexpected consequence, once multi-map management was enabled. Indeed,
when enabling a map without any spatial layers, it seems we set it an
actual enveloppe. Consequently, some tests in
MapControl$RefreshLayerListener#layerAdded failed, and we do not adjust
extent anymore. Moreover, we don't zoom to the first added layer either.

This commit intends to fix that. The test it performs is more general :
it basically counts the spatial layers in the layer model and, if there
is exactly one, it sets the adjustExtent and the extent to the needed
values in the MapTransform.
