### PR TITLE
Fix a bug in the TableImportPanel. It used the same DBSource declaration

### DIFF
--- a/orbisgis-view/src/main/java/org/orbisgis/view/geocatalog/sourceWizards/db/TableImportPanel.java
+++ b/orbisgis-view/src/main/java/org/orbisgis/view/geocatalog/sourceWizards/db/TableImportPanel.java
@@ -243,14 +243,15 @@ public class TableImportPanel extends JDialog {
                         for (int i = 0; i < selectedNodes; i++) {
                                 Object selectedObject = ((DefaultMutableTreeNode) treePath[i].getLastPathComponent()).getUserObject();
                                 if (selectedObject instanceof TableNode) {
-                                        TableNode tableNode = (TableNode) selectedObject;
+					DBSource clonedDBSource = dBSource.clone();
+					TableNode tableNode = (TableNode) selectedObject;
                                         String tableName = tableNode.getName();
-                                        dBSource.setTableName(tableName);
-                                        dBSource.setSchemaName(tableNode.getSchema());
+                                        clonedDBSource.setTableName(tableName);
+                                        clonedDBSource.setSchemaName(tableNode.getSchema());
                                         if (sourceManager.exists(tableName)) {
                                                 tableName = sourceManager.getUniqueName(tableName);
                                         }
-                                        sourceManager.register(tableName, new DBTableSourceDefinition(dBSource));
+                                        sourceManager.register(tableName, new DBTableSourceDefinition(clonedDBSource));
                                 }
                         }
                         dispose();


### PR DESCRIPTION
to create all the GDMS DataSources. That was a problem as we were
modifiying objects used by existing DataSources. When
checking that the objects did not already exist, we were comparing
DBTableSourceDefinition that had equal DBSource... so the table was not
added.

Fixed by using the new clone method in dBSource.
