### PR TITLE
Fix a problem with the GeoJSON parser. 

### DIFF
--- a/gdms/src/main/scala/org/gdms/driver/geojson/Parser.scala
+++ b/gdms/src/main/scala/org/gdms/driver/geojson/Parser.scala
@@ -150,15 +150,17 @@ trait Parser {
    */
   private def buildMetadata(vals: Map[String, Int], met: DefaultMetadata) {
     // change NULL type to String type (with NULL values)
-    val cvals = vals map { 
+    val cvals = vals map {
       case (n, v) if v == NULL => (n, STRING)
       case a => a
     }
     
     // reorder to get 'the_geom' first
-    met.addField("the_geom", cvals.head._2)
-    cvals.tail foreach { case (n, v) => met.addField(n, v) }
-    
+    met.addField("the_geom", cvals.get("$").getOrElse(STRING))
+    cvals foreach {
+      case ("$", _) =>  //Already added.
+      case (n, v) => met.addField(n, v)
+    }
   }
     
   /**

--- a/gdms/src/test/java/org/gdms/drivers/GeoJsonImporterTest.java
+++ b/gdms/src/test/java/org/gdms/drivers/GeoJsonImporterTest.java
@@ -48,6 +48,7 @@ import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.LineString;
 import com.vividsolutions.jts.geom.LinearRing;
 import com.vividsolutions.jts.geom.Polygon;
+import org.gdms.driver.geojson.GeoJsonImporter;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -315,5 +316,26 @@ public class GeoJsonImporterTest {
                 assertEquals(Type.INT, met.getFieldType(1).getTypeCode());
                 assertEquals("name", met.getFieldName(2));
                 assertEquals(Type.STRING, met.getFieldType(2).getTypeCode());
+        }
+
+        @Test
+        public void testProbFile() throws Exception {
+                JsonFactory f = new JsonFactory();
+                JsonParser jp = f.createJsonParser(new File("/home/alexis/gitProjects/orbisgis-irstv/gdms/src/test/resources/org/gdms/drivers/Metadata-order.json"));
+                DummyParser p = new DummyParser();
+                Metadata met = p.metadata(jp);
+                checkType(met, "the_geom", Type.POINT);
+                checkType(met, "ID", Type.STRING);
+                checkType(met, "ID_COM", Type.STRING);
+                checkType(met, "ORIGIN_NOM", Type.STRING);
+                checkType(met, "NATURE", Type.STRING);
+                checkType(met, "NOM", Type.STRING);
+                checkType(met, "IMPORTANCE", Type.STRING);
+                assertTrue(true);
+        }
+
+        private void checkType(Metadata m, String name, int type) throws Exception{
+                int i = m.getFieldIndex(name);
+                assertTrue(m.getFieldType(i).getTypeCode() == type);
         }
 }

--- a/gdms/src/test/resources/org/gdms/drivers/Metadata-order.json
+++ b/gdms/src/test/resources/org/gdms/drivers/Metadata-order.json
@@ -1,0 +1,1 @@
+{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[294427.0,2246024.0]},"properties":{"ID":"PAIHABIT0000000028862035","IMPORTANCE":"4","NOM":"bouaye","ORIGIN_NOM":"BDNyme","ID_COM":"SURFCOMM0000000029998995","NATURE":"Canton"}}]}


### PR DESCRIPTION
There was a problem whithe the management of metadata.
The original sorted map was not kept but replace
by a HahsMap. Then, we were betting on the fact the insertion order of
the HashMap would be kept. It is not. It is expected not to be. And that
caused the bug : Metadata were not presented altered the right way.

I've added a test case for this. The input file has been produced from a
data file that were correctly exported to JSON, but not correctly
imported back. Metadata were misplaced on the columns... Should be fixed
now. Even if I'm afraid we may face other similar, but more complicated,
problems in this piece of code.
