### PR TITLE
Fix the order of entries in the Geocatalog menu, as described in #161.

### DIFF
--- a/orbisgis-view/src/main/java/org/orbisgis/view/geocatalog/Catalog.java
+++ b/orbisgis-view/src/main/java/org/orbisgis/view/geocatalog/Catalog.java
@@ -565,6 +565,8 @@ public class Catalog extends JPanel implements DockingPanel {
                                 this,
                                 "onMenuSaveInDB"));
                         saveMenu.add(saveInDBItem);
+                        //Separator between add/save/new and the attribute table.
+                        rootMenu.addSeparator();
                         //Popup:Open attributes
                         JMenuItem openTableMenu = new JMenuItem(I18N.tr("Open the attributes"),
                                 OrbisGISIcon.getIcon("openattributes"));
@@ -576,6 +578,18 @@ public class Catalog extends JPanel implements DockingPanel {
 
                 rootMenu.addSeparator();
 
+                //Add function to remove a source
+                if (!sourceList.isSelectionEmpty()) {
+
+                        JMenuItem removeSourceItem = new JMenuItem(
+                                    I18N.tr("Remove the source"),
+                                    OrbisGISIcon.getIcon("remove"));
+                        removeSourceItem.addActionListener(EventHandler.create(ActionListener.class,
+                                    this,
+                                    "onMenuRemoveSource"));
+                        rootMenu.add(removeSourceItem);
+                }
+
                 //Popup:ClearGeocatalog (added if the datasource manager is not empty)
                 DataManager dm = Services.getService(DataManager.class);
                 SourceManager dr = dm.getSourceManager();
@@ -586,18 +600,6 @@ public class Catalog extends JPanel implements DockingPanel {
                                 this,
                                 "onMenuClearGeoCatalog"));
                         rootMenu.add(clearCatalogItem);
-                }
-
-                //Add function to remove a source
-                if (!sourceList.isSelectionEmpty()) {
-
-                        JMenuItem removeSourceItem = new JMenuItem(
-                                I18N.tr("Remove the source"),
-                                OrbisGISIcon.getIcon("remove"));
-                        removeSourceItem.addActionListener(EventHandler.create(ActionListener.class,
-                                this,
-                                "onMenuRemoveSource"));
-                        rootMenu.add(removeSourceItem);
                 }
 
                 //////////////////////////////


### PR DESCRIPTION
Partial fix, though, as we still miss two entries.
