### PR TITLE
Improve the way a separator is added in the geocatalog menu.

### DIFF
--- a/orbisgis-view/src/main/java/org/orbisgis/view/geocatalog/Catalog.java
+++ b/orbisgis-view/src/main/java/org/orbisgis/view/geocatalog/Catalog.java
@@ -573,13 +573,7 @@ public class Catalog extends JPanel implements DockingPanel {
                         openTableMenu.addActionListener(EventHandler.create(ActionListener.class,
                                 this, "onMenuShowTable"));
                         rootMenu.add(openTableMenu);
-                        
-                }
-
-                rootMenu.addSeparator();
-
-                //Add function to remove a source
-                if (!sourceList.isSelectionEmpty()) {
+                        rootMenu.addSeparator();
 
                         JMenuItem removeSourceItem = new JMenuItem(
                                     I18N.tr("Remove the source"),


### PR DESCRIPTION
I don't know why it was made ouside the if blocks... as both are using
the same condition.
