### PR TITLE
The ready method is not an efficient way to check that we've finished to

### DIFF
--- a/orbisgis-view/src/main/java/org/orbisgis/view/components/fstree/TreeNodeFolder.java
+++ b/orbisgis-view/src/main/java/org/orbisgis/view/components/fstree/TreeNodeFolder.java
@@ -374,8 +374,10 @@ public class TreeNodeFolder extends AbstractTreeNodeContainer implements PopupTr
                         // If the file exists found a new one
                         fileName = getUniqueFileName(fileName);
                         FileWriter writer = new FileWriter(fileName);
-                        while (br.ready()) {
-                                writer.write(br.read());
+                        String res = br.readLine();
+                        while (res != null) {
+                                writer.write(res+"\n");
+                                res = br.readLine();
                         }
                         writer.close();
                         return true;


### PR DESCRIPTION
read the incoming document. The transfer may become not ready while the
data are copied. So we must not rely on it...
I use readLine instead, as it seems to be the more efficient for me.
There may be better ways, though...
