### PR TITLE
As described in #197, when removing the last letter of a filter, nothing...

### DIFF
--- a/orbisgis-view/src/main/java/org/orbisgis/view/components/filter/DefaultActiveFilter.java
+++ b/orbisgis-view/src/main/java/org/orbisgis/view/components/filter/DefaultActiveFilter.java
@@ -76,8 +76,9 @@ public class DefaultActiveFilter extends ActiveFilter {
          * @param currentFilterValue new value of currentFilterValue
          */
         public void setCurrentFilterValue(String currentFilterValue) {
+                String oldV = this.currentFilterValue;
                 this.currentFilterValue = currentFilterValue;
                 //Do not send older value to execute again the filter even if the field is the same
-                propertySupport.firePropertyChange(PROP_CURRENTFILTERVALUE, "", currentFilterValue); 
+                propertySupport.firePropertyChange(PROP_CURRENTFILTERVALUE, oldV, currentFilterValue);
         }
 }


### PR DESCRIPTION
... happened.

Indeed, when deciding if we had to fire an event or not, we were using
the empty string as the old value in any situations. Consequently, when
the new string is empty string while the old one is not, we fail. That
should be fixed now, as we use the actual old value when calling
firePropertyChange.
