### PR TITLE
Change rsyntax version

### DIFF
--- a/orbisgis-view/pom.xml
+++ b/orbisgis-view/pom.xml
@@ -76,12 +76,12 @@
                 <dependency>
                         <groupId>com.fifesoft</groupId>
                         <artifactId>autocomplete</artifactId>
-                        <version>2.0.3</version>
+                        <version>2.0.5.1</version>
                 </dependency>
                 <dependency>
                         <groupId>com.fifesoft</groupId>
                         <artifactId>rsyntaxtextarea</artifactId>
-                        <version>2.0.3</version>
+                        <version>2.0.5.1</version>
                 </dependency>
                 <dependency>
                         <groupId>org.dockingframes</groupId>
@@ -118,7 +118,7 @@
                 <dependency>
                         <groupId>com.fifesoft</groupId>
                         <artifactId>languagesupport</artifactId>
-                        <version>0.8-1</version>
+                        <version>0.9.1</version>
                 </dependency>
                 <dependency>
                     <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
Fix #231

The old version use javax.ImageIO with an incorrect provider (com.sun.java..). Then the old RsyntaxArea is not compatible with OpenJDK.
