### PR TITLE
Fix an exception while loading the Advanced editor

### DIFF
--- a/orbisgis-view/src/main/java/org/orbisgis/view/toc/actions/cui/graphic/LegendUICompositeGraphicPanel.java
+++ b/orbisgis-view/src/main/java/org/orbisgis/view/toc/actions/cui/graphic/LegendUICompositeGraphicPanel.java
@@ -108,14 +108,6 @@ public class LegendUICompositeGraphicPanel extends LegendUIComponent {
 
         currentGraphic = -1;
 
-        int i;
-        for (i = 0; i < gc.getNumGraphics(); i++) {
-            Graphic graphic = gc.getGraphic(i);
-            LegendUIComponent gPanel = getCompForGraphic(graphic);
-            graphics.add(gPanel);
-            model.addElement(graphic);
-        }
-
         list = new JList(model);
         list.setCellRenderer(new CellRenderer());
         list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
@@ -124,6 +116,14 @@ public class LegendUICompositeGraphicPanel extends LegendUIComponent {
         btnAdd = new JButton(OrbisGISIcon.getIcon("add"));
         btnDown = new JButton(OrbisGISIcon.getIcon("go-down"));
         btnUp = new JButton(OrbisGISIcon.getIcon("go-up"));
+
+        int i;
+        for (i = 0; i < gc.getNumGraphics(); i++) {
+            Graphic graphic = gc.getGraphic(i);
+            LegendUIComponent gPanel = getCompForGraphic(graphic);
+            graphics.add(gPanel);
+            model.addElement(graphic);
+        }
 
 
         btnRm.setMargin(new Insets(0, 0, 0, 0));


### PR DESCRIPTION
We were trying to handle "list" before having instanciated it, so we obtained a wonderful NPE. I moved some code, it should be better... I don't obtain the exception anymore. @agouge should be pleased with that :-)
