### PR TITLE
Fix deadlock

### DIFF
--- a/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/ActionBundle.java
+++ b/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/ActionBundle.java
@@ -62,40 +62,8 @@ public class ActionBundle extends AbstractAction {
 
     public void actionPerformed(ActionEvent actionEvent) {
         setEnabled(false);
-        (new BackgroundProcess(actionEvent)).execute();
+        // If this is done outside the SwingEventThread then a thread lock can occur
+        action.actionPerformed(actionEvent);
     }
 
-    /**
-     * Process bundle actions in background.
-     */
-    private class BackgroundProcess extends SwingWorker<Integer,Integer> {
-        private ActionEvent actionEvent;
-
-        private BackgroundProcess(ActionEvent actionEvent) {
-            this.actionEvent = actionEvent;
-        }
-
-        @Override
-        protected Integer doInBackground() throws Exception {
-            if(action!=null) {
-                try {
-                    action.actionPerformed(actionEvent);
-                } catch( Exception ex) {
-                    LOGGER.error(ex.getLocalizedMessage(),ex);
-                }
-            }
-            return null;
-        }
-
-
-        @Override
-        public String toString() {
-            return "ActionBundle#BackgroundProcess";
-        }
-
-        @Override
-        protected void done() {
-            setEnabled(true);
-        }
-    }
 }

--- a/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/BundleListModel.java
+++ b/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/BundleListModel.java
@@ -133,7 +133,7 @@ public class BundleListModel extends AbstractListModel {
                         fireContentsChanged(this,index,index);
                     }
                 } else {
-                    BundleItem newBundle = new BundleItem();
+                    BundleItem newBundle = new BundleItem(bundleContext);
                     newBundle.setBundle(bundle);
                     curBundles.put(getIdentifier(bundle),newBundle);
                     int index = storedBundles.size();
@@ -170,7 +170,7 @@ public class BundleListModel extends AbstractListModel {
                         fireContentsChanged(this,index,index);
                     }
                 } else {
-                    BundleItem newBundle = new BundleItem();
+                    BundleItem newBundle = new BundleItem(bundleContext);
                     newBundle.setObrResource(resource);
                     curBundles.put(getIdentifier(resource),newBundle);
                     int index = storedBundles.size();


### PR DESCRIPTION
Running Bundle.update() on another thread than swing thread invokes a deadlock because we should not manage bundle event while updating.

Doing Start,Update,Download etc on Bundle freezes the swing Ui. To get rid of that we should use the same thread every time we manage bundles. This could be done later..
