### PR TITLE
Use a tagged version of DockingFrames

### DIFF
--- a/orbisgis-view/pom.xml
+++ b/orbisgis-view/pom.xml
@@ -91,7 +91,7 @@
                 <dependency>
                     <groupId>org.dockingframes</groupId>
                     <artifactId>docking-frames-ext-toolbar-common</artifactId>
-                    <version>1.1.2-SNAPSHOT</version>
+                    <version>1.1.2-ORBISGIS</version>
                 </dependency>
                 <dependency>
                         <groupId>junit</groupId>


### PR DESCRIPTION
Use a tagged version of DockingFrames in order to use a specific snapshot release compiled on our maven repository. This version will be fixed when DockingFrames will release a version with toolbars included.
