### PR TITLE
Fix a test linked to the shapefile driver.

### DIFF
--- a/gdms/src/main/java/org/gdms/driver/shapefile/PolygonHandler.java
+++ b/gdms/src/main/java/org/gdms/driver/shapefile/PolygonHandler.java
@@ -188,7 +188,7 @@ public class PolygonHandler implements ShapeHandler {
 
                         length = finish - start;
 
-                        CoordinateSequence csRing = geometryFactory.getCoordinateSequenceFactory().create(length, dimensions);
+                        CoordinateSequence csRing = geometryFactory.getCoordinateSequenceFactory().create(length, 3);
                         // double area = 0;
                         // int sx = offset;
                         for (int i = 0; i < length; i++) {


### PR DESCRIPTION
We had a problem in the shapefile reader with the last JTS release.
Indeed, we were not forcing the dimension to 3 so that we couldn't
change the dimension later. Dimension management in JTS is still not
perfect : we currently can't change dimension during runtime. Anyway, it
should work for us now. have a look at #341 for more details about the problem.
