### PR TITLE
Fix a validation problem that can prevent edition.

### DIFF
--- a/gdms/src/main/java/org/gdms/data/types/LengthConstraint.java
+++ b/gdms/src/main/java/org/gdms/data/types/LengthConstraint.java
@@ -56,7 +56,7 @@ public final class LengthConstraint extends AbstractIntConstraint {
 
         @Override
 	public String check(Value value) {
-	 if (value.toString().length() > constraintValue) {
+	 if (!value.isNull() && value.toString().length() > constraintValue) {
 			return "Maximum length is " + constraintValue;
 		}
 		

--- a/gdms/src/test/java/org/gdms/data/types/ConstraintTest.java
+++ b/gdms/src/test/java/org/gdms/data/types/ConstraintTest.java
@@ -459,6 +459,17 @@ public class ConstraintTest extends TestBase {
                 assertTrue(TypeFactory.canBeCastTo(Type.TIME, Type.TIMESTAMP));
         }
 
+        @Test
+        public void testNullLengthWorks() throws Exception {
+            Value nv = ValueFactory.createNullValue();
+            LengthConstraint lc = new LengthConstraint(3);
+            assertTrue(lc.check(nv) == null);
+            lc = new LengthConstraint(2);
+            assertTrue(lc.check(nv) == null);
+            lc = new LengthConstraint(4);
+            assertTrue(lc.check(nv) == null);
+        }
+
         private void checkUniqueness() throws DriverException {
                 DataSource ds = getDataSource();
                 ds.open();

--- a/orbisgis-view/src/main/java/org/orbisgis/view/map/tools/PolygonTool.java
+++ b/orbisgis-view/src/main/java/org/orbisgis/view/map/tools/PolygonTool.java
@@ -72,7 +72,7 @@ public class PolygonTool extends AbstractPolygonTool {
 			row = ToolUtilities.populateNotNullFields(sds, row);
 			sds.insertFilledRow(row);
 		} catch (DriverException e) {
-			throw new TransitionException("Cannot insert polygon", e);
+			throw new TransitionException("Cannot insert polygon :"+e.getMessage(), e);
 		}
 	}
 


### PR DESCRIPTION
LengthConstraint did not validate null values the good way. We are not
interested in the toString() representation of NullValue instances but
in the fact they are null and consequently don't have a length. A null
value can't be invalidate by a constraint put on length.

That should solve the problem described in #338. Finally, this ticket is
not really linked to edition but to constraints. I've improved the error
message returned by PolygonTools when facing a DriverException, too. The
previous one was quite... frustrating...
