### PR TITLE
Fix StackOverflow on MapControl

### DIFF
--- a/orbisgis-view/src/main/java/org/orbisgis/view/map/MapControl.java
+++ b/orbisgis-view/src/main/java/org/orbisgis/view/map/MapControl.java
@@ -604,7 +604,7 @@ public class MapControl extends JComponent implements ContainerListener {
                             MapTransform mapTransform) {
                     invalidateImage();
                     // Record new BoundingBox value for map context
-                    mapContext.setBoundingBox(mapTransform.getAdjustedExtent());
+                    mapContext.setBoundingBox(mapTransform.getExtent());
             }            
         }
         

--- a/orbisgis-view/src/main/java/org/orbisgis/view/toc/TocTreeSelectionIterable.java
+++ b/orbisgis-view/src/main/java/org/orbisgis/view/toc/TocTreeSelectionIterable.java
@@ -77,6 +77,7 @@ public class TocTreeSelectionIterable<Node extends TreeNode> implements Iterable
             return hasNext;
         }
 
+        @Override
         public Node next() {
             index++;
             if(index >= selected.length) {


### PR DESCRIPTION
AdjustedExtent is window related extent and has not to be used in the MapContext.
