### PR TITLE
OSGi, take bundle version when package version is not available

### DIFF
--- a/orbisgis-core/src/main/java/org/orbisgis/core/plugin/BundleTools.java
+++ b/orbisgis-core/src/main/java/org/orbisgis/core/plugin/BundleTools.java
@@ -30,7 +30,6 @@ package org.orbisgis.core.plugin;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FilenameFilter;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -40,7 +39,6 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;

--- a/orbisgis-core/src/test/java/org/orbisgis/core/plugin/BundleToolsTest.java
+++ b/orbisgis-core/src/test/java/org/orbisgis/core/plugin/BundleToolsTest.java
@@ -51,13 +51,17 @@ public class BundleToolsTest {
         InputStream manifestStream = BundleToolsTest.class.getResourceAsStream("MANIFEST.MF");
         Manifest manifest = new Manifest(manifestStream);
         BundleTools.parseManifest(manifest,packages);
-        Assert.assertEquals(2,packages.size());
+        Assert.assertEquals(3,packages.size());
         PackageDeclaration packageInfo = packages.get(0);
         Assert.assertEquals("org.xnap.commons.i18n",packageInfo.getPackageName());
         Assert.assertEquals(new Version(0,9,6),packageInfo.getVersion());
         packageInfo = packages.get(1);
+        // BundleTools will use the Bundle version if the package version is not available
         Assert.assertEquals("org.xnap.commons.i18n.nover",packageInfo.getPackageName());
-        Assert.assertEquals(false,packageInfo.isVersionDefined());
+        Assert.assertEquals(new Version(0,9,6),packageInfo.getVersion());
+        packageInfo = packages.get(2);
+        Assert.assertEquals("org.xnap.commons.i18n.bla",packageInfo.getPackageName());
+        Assert.assertEquals(new Version(0,5,0),packageInfo.getVersion());
 
     }
 }

--- a/orbisgis-core/src/test/resources/org/orbisgis/core/plugin/MANIFEST.MF
+++ b/orbisgis-core/src/test/resources/org/orbisgis/core/plugin/MANIFEST.MF
@@ -10,6 +10,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Gettext Commons
 Bundle-SymbolicName: gettext-commons
 Bundle-Version: 0.9.6
-Export-Package: org.xnap.commons.i18n;version="0.9.6",org.xnap.commons.i18n.nover
+Export-Package: org.xnap.commons.i18n;version="0.9.6",org.xnap.commons.i18n.nover,org.xnap.commons.i18n.bla;version="0.5.0"
 Tool: Bnd-1.50.0
 


### PR DESCRIPTION
Fix SL4J dependency issue (core does not export the package version)
