### PR TITLE
Fix toobar init

### DIFF
--- a/orbisgis-view/src/main/java/org/orbisgis/view/docking/DockingManagerImpl.java
+++ b/orbisgis-view/src/main/java/org/orbisgis/view/docking/DockingManagerImpl.java
@@ -223,6 +223,8 @@ public final class DockingManagerImpl extends BeanPropertyChangeSupport implemen
                         if(!item.isVisible() && item.getAction()!=null) {
                             doReset = true;
                             // Reset layout
+                            // Unlink action and removed ToolBar item
+                            item.resetItem();
                             commonControl.removeSingleDockable(item.getUniqueId());
                         }
                 }


### PR DESCRIPTION
When a toolbar is not in the layout, dockingmanager remove the toolbar item and recreate it (missing unlinking of action)

Before this PR the user cannot draw on the first launch of OrbisGIS cause null CControl.
