### PR TITLE
About 414 - NPE when dragging a source on the Map.

### DIFF
--- a/orbisgis-view/src/main/java/org/orbisgis/view/map/MapEditor.java
+++ b/orbisgis-view/src/main/java/org/orbisgis/view/map/MapEditor.java
@@ -601,7 +601,7 @@ public class MapEditor extends JPanel implements TransformListener, MapEditorExt
                 if(eElement instanceof EditableSource) {
                     try {
                         EditableSource edit = (EditableSource) eElement;
-                        if(!edit.isOpen()){
+                        if(edit.getDataSource() == null){
                             edit.open(new NullProgressMonitor());
                             edit.close(new NullProgressMonitor());
                         }


### PR DESCRIPTION
Because of a rework of this method, the DataSource sent to the LayerModel was null. The inner DataSource of EditableSource instances is lazy initialized. To linked an EditableSource to a DataSource, we must call open. I call close too so that we won't have problems, with OCCounterDecorator for instance.
