### PR TITLE
Fix #363 by ignoring whitespace characters.

### DIFF
--- a/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/MainPanel.java
+++ b/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/MainPanel.java
@@ -449,7 +449,7 @@ public class MainPanel extends JPanel {
             //If a string was returned, say so.
             if ((chosenURL != null)) {
                 try {
-                    URI userURI = new URI(chosenURL);
+                    URI userURI = new URI(chosenURL.trim());
                     bundleContext.installBundle(userURI.toString());
                     return;
                 } catch(Exception ex) {


### PR DESCRIPTION
It's all in the title. Now (trailing) whitespace characters are ignored when a user enters a repository URL.
