### PR TITLE
Make a copy of list before iterating over

### DIFF
--- a/orbisgis-view/src/main/java/org/orbisgis/view/toc/Toc.java
+++ b/orbisgis-view/src/main/java/org/orbisgis/view/toc/Toc.java
@@ -698,6 +698,7 @@ public class Toc extends JPanel implements EditorDockable, TocExt {
                         this.mapContext.removeMapContextListener(tocMapContextListener);
                         this.mapContext.removePropertyChangeListener(mapContextPropertyChange);
                         mapElement.removePropertyChangeListener(modificationListener);
+                        // We make a copy of the list to avoid ConcurrentModificationExceptions. See #421.
                         for(TableEditableElement editable : new ArrayList<TableEditableElement>(linkedEditableElements.values())) {
                                 unlinkTableSelectionListening(editable);
                         }


### PR DESCRIPTION
About #417
The method unlinkTableSelectionListening updates the map linkedEditableElements. We have to create a copy of the values before iterating over.
