### PR TITLE
Use new snapshot version for gdms

### DIFF
--- a/bundles/plugin-test/pom.xml
+++ b/bundles/plugin-test/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.gdms</groupId>
             <artifactId>gdms</artifactId>
-            <version>2.0-SNAPSHOT</version>
+            <version>${gdms-version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/gdms/pom.xml
+++ b/gdms/pom.xml
@@ -11,7 +11,7 @@
     <groupId>org.gdms</groupId>
     <artifactId>gdms</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.2</version>
+    <version>${gdms-version}</version>
     <name>gdms</name>
     <url>http://www.orbisgis.org</url>
     <repositories>  

--- a/orbisgis-core/pom.xml
+++ b/orbisgis-core/pom.xml
@@ -116,7 +116,7 @@
                 <dependency>
                         <groupId>org.gdms</groupId>
                         <artifactId>gdms</artifactId>
-                        <version>2.0.2</version>
+                        <version>${gdms-version}</version>
                 </dependency>
                 <dependency>
                         <groupId>javax.media</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <properties>
                 <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
                 <netbeans.hint.license>OrbisGIS</netbeans.hint.license>
+                <gdms-version>2.0.3-SNAPSHOT</gdms-version>
         </properties>
         <scm>
                 <connection>scm:git:https://github.com/irstv/orbisgis.git</connection>


### PR DESCRIPTION
Fix, some issues with dependency resolution on new non-snapshot release. Use property in order to make easier update later. 
