### PR TITLE
Linked to issue #459

### DIFF
--- a/legend/src/main/java/org/orbisgis/legend/structure/viewbox/ConstantViewBox.java
+++ b/legend/src/main/java/org/orbisgis/legend/structure/viewbox/ConstantViewBox.java
@@ -108,8 +108,9 @@ public class ConstantViewBox extends DefaultViewBox {
         public void setHeight(Double d) {
             if(d==null){
                 if(getWidth() != null){
-                    setHeightLegend(null);
-                    getViewBox().setHeight(null);
+                    RealLiteral rl = new RealLiteral(getWidth());
+                    setHeightLegend(new RealLiteralLegend(rl));
+                    getViewBox().setHeight(rl);
                 } else {
                     throw new IllegalArgumentException("you're not supposed to"
                             + "set both height and width of a viewbox to null.");
@@ -138,8 +139,9 @@ public class ConstantViewBox extends DefaultViewBox {
         public void setWidth(Double d) {
             if(d==null){
                 if(getHeight() != null){
-                    setWidthLegend(null);
-                    getViewBox().setWidth(null);
+                    RealLiteral rl = new RealLiteral(getHeight());
+                    setWidthLegend(new RealLiteralLegend(rl));
+                    getViewBox().setWidth(rl);
                 } else {
                     throw new IllegalArgumentException("you're not supposed to"
                             + "set both height and width of a viewbox to null.");

--- a/legend/src/main/java/org/orbisgis/legend/thematic/constant/UniqueSymbolPoint.java
+++ b/legend/src/main/java/org/orbisgis/legend/thematic/constant/UniqueSymbolPoint.java
@@ -90,6 +90,8 @@ public class UniqueSymbolPoint extends ConstantFormPoint implements IUniqueSymbo
             if(gr instanceof MarkGraphic){
                 markGraphic = new ConstantWKNLegend((MarkGraphic)gr);
             }
+            setViewBoxHeight(getViewBoxHeight());
+            setViewBoxWidth(getViewBoxWidth());
         } else {
             throw new IllegalArgumentException("We can't analyze symbolizers with"
                     + "graphic collections.");

--- a/legend/src/test/java/org/orbisgis/legend/analyzer/PointSymbolizerAnalyzerTest.java
+++ b/legend/src/test/java/org/orbisgis/legend/analyzer/PointSymbolizerAnalyzerTest.java
@@ -28,16 +28,13 @@
  */
 package org.orbisgis.legend.analyzer;
 
-import java.awt.Color;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import org.junit.Test;
 import org.orbisgis.core.renderer.se.PointSymbolizer;
 import org.orbisgis.core.renderer.se.Style;
 import org.orbisgis.core.renderer.se.common.Uom;
 import org.orbisgis.core.renderer.se.fill.SolidFill;
 import org.orbisgis.core.renderer.se.graphic.MarkGraphic;
+import org.orbisgis.core.renderer.se.graphic.ViewBox;
 import org.orbisgis.core.renderer.se.parameter.string.InvalidString;
 import org.orbisgis.core.renderer.se.parameter.string.StringLiteral;
 import org.orbisgis.core.renderer.se.stroke.PenStroke;
@@ -46,6 +43,10 @@ import org.orbisgis.legend.analyzer.symbolizers.PointSymbolizerAnalyzer;
 import org.orbisgis.legend.structure.viewbox.ConstantViewBox;
 import org.orbisgis.legend.thematic.categorize.CategorizedPoint;
 import org.orbisgis.legend.thematic.constant.UniqueSymbolPoint;
+
+import java.awt.*;
+
+import static org.junit.Assert.*;
 
 /**
  *
@@ -308,7 +309,7 @@ public class PointSymbolizerAnalyzerTest extends AnalyzerTest {
         assertTrue(mg.getViewBox().getHeight() == null);
         assertTrue(mg.getViewBox().getWidth().getValue(null, 0) == 5);
         UniqueSymbolPoint uvp = new UniqueSymbolPoint(ps);
-        assertTrue(uvp.getViewBoxHeight() == null);
+        assertTrue(uvp.getViewBoxHeight() == 5);
         assertTrue(uvp.getViewBoxWidth() == 5);
     }
 
@@ -343,34 +344,44 @@ public class PointSymbolizerAnalyzerTest extends AnalyzerTest {
         assertTrue(mg.getViewBox().getWidth().getValue(null, 0) == 5);
         UniqueSymbolPoint uvp = new UniqueSymbolPoint(ps);
         uvp.setViewBoxWidth(15.0);
-        assertTrue(uvp.getViewBoxHeight() == null);
+        assertTrue(uvp.getViewBoxHeight() == 5.0);
         assertTrue(uvp.getViewBoxWidth() == 15.0);
         uvp.setViewBoxHeight(16.0);
         assertTrue(uvp.getViewBoxHeight() == 16.0);
         assertTrue(uvp.getViewBoxWidth() == 15.0);
         uvp.setViewBoxWidth(null);
         assertTrue(uvp.getViewBoxHeight() == 16.0);
-        assertTrue(uvp.getViewBoxWidth() == null);
+        assertTrue(uvp.getViewBoxWidth() == 16.0);
         uvp.setViewBoxWidth(15.0);
         assertTrue(uvp.getViewBoxHeight() == 16.0);
         assertTrue(uvp.getViewBoxWidth() == 15.0);
         uvp.setViewBoxHeight(null);
-        assertTrue(uvp.getViewBoxHeight() == null);
+        assertTrue(uvp.getViewBoxHeight() == 15.0);
         assertTrue(uvp.getViewBoxWidth() == 15.0);
-        try{
-            uvp.setViewBoxWidth(null);
-            fail();
-        } catch(IllegalArgumentException iae){
-            assertTrue(true);
-        }
-        uvp.setViewBoxHeight(16.0);
-        uvp.setViewBoxWidth(null);
-        try{
-            uvp.setViewBoxHeight(null);
-            fail();
-        } catch(IllegalArgumentException iae){
-            assertTrue(true);
-        }
+    }
+
+    @Test
+    public void testWithoutWidth() throws Exception {
+        PointSymbolizer ps = new PointSymbolizer();
+        ViewBox viewBox = ((MarkGraphic) ps.getGraphicCollection().getGraphic(0)).getViewBox();
+        viewBox.setHeight(null);
+        UniqueSymbolPoint usp = new UniqueSymbolPoint(ps);
+        assertTrue(usp.getViewBoxHeight().equals(usp.getViewBoxWidth()));
+        assertTrue(usp.getViewBoxHeight().equals(MarkGraphic.DEFAULT_SIZE));
+        usp.setViewBoxWidth(27.27);
+        assertFalse(usp.getViewBoxHeight().equals(27.27));
+    }
+
+    @Test
+    public void testWithoutHeight() throws Exception {
+        PointSymbolizer ps = new PointSymbolizer();
+        ViewBox viewBox = ((MarkGraphic) ps.getGraphicCollection().getGraphic(0)).getViewBox();
+        viewBox.setWidth(null);
+        UniqueSymbolPoint usp = new UniqueSymbolPoint(ps);
+        assertTrue(usp.getViewBoxHeight().equals(usp.getViewBoxWidth()));
+        assertTrue(usp.getViewBoxHeight().equals(MarkGraphic.DEFAULT_SIZE));
+        usp.setViewBoxHeight(27.27);
+        assertFalse(usp.getViewBoxWidth().equals(27.27));
     }
 
     @Test

--- a/orbisgis-core/src/main/java/org/orbisgis/core/renderer/se/graphic/MarkGraphic.java
+++ b/orbisgis-core/src/main/java/org/orbisgis/core/renderer/se/graphic/MarkGraphic.java
@@ -123,7 +123,7 @@ public final class MarkGraphic extends Graphic implements FillNode, StrokeNode,
         this.setUom(Uom.MM);
         this.setWkn(new StringLiteral("circle"));
 
-        this.setViewBox(new ViewBox(new RealLiteral(DEFAULT_SIZE)));
+        this.setViewBox(new ViewBox(new RealLiteral(DEFAULT_SIZE), new RealLiteral(DEFAULT_SIZE)));
         this.setFill(new SolidFill());
         ((RealLiteral) ((SolidFill) this.getFill()).getOpacity()).setValue(100.0);
         this.setStroke(new PenStroke());

--- a/orbisgis-core/src/main/java/org/orbisgis/core/renderer/se/graphic/ViewBox.java
+++ b/orbisgis-core/src/main/java/org/orbisgis/core/renderer/se/graphic/ViewBox.java
@@ -45,9 +45,9 @@ import org.orbisgis.core.renderer.se.parameter.real.RealParameter;
 import org.orbisgis.core.renderer.se.parameter.real.RealParameterContext;
 
 /**
- * {@code ViewBox} supplies a simplen and convenient method to change the view box of a graphic,
+ * {@code ViewBox} supplies a simple and convenient method to change the view box of a graphic,
  * in a {@link MarkGraphic} for instance.
- * {@code ViewBox} is bult using the following parameters :
+ * {@code ViewBox} is built using the following parameters :
  * <ul><li>X : the width of the box.</li>
  * <li>Y : the height of the box.</li></ul>
  * If only one of these two is given, they are considered to be equal.</p>
@@ -75,7 +75,15 @@ public final class ViewBox extends  AbstractSymbolizerNode {
          * Build a new {@code ViewBox}, using the given width.
          */
         public ViewBox(RealParameter width) {
-                setWidth(width);
+            setWidth(width);
+        }
+
+        /**
+         * Build a new {@code ViewBox}, using the given width and height.
+         */
+        public ViewBox(RealParameter width, RealParameter height) {
+            setWidth(width);
+            setHeight(height);
         }
 
         /**


### PR DESCRIPTION
Two changes here :
- The default MarkGraphic now explicitly sets both height and width
- If a MarkGraphic with a null dimension is given to a
  UniqueSymbolPoint, its missing dimension is set.
