### PR TITLE
The stroke configuration could still be edited even if it was disabled

### DIFF
--- a/orbisgis-view/src/main/java/org/orbisgis/view/toc/actions/cui/legends/PnlUniqueAreaSE.java
+++ b/orbisgis-view/src/main/java/org/orbisgis/view/toc/actions/cui/legends/PnlUniqueAreaSE.java
@@ -285,6 +285,14 @@ public class PnlUniqueAreaSE extends PnlUniqueLineSE {
         }
 
         /**
+         * If true, the stroke parameters shown by the UI must be enabled. They are disabled otherwise.
+         * @return If the stroke parameters can be edited
+         */
+        protected boolean isStrokeEnabled(){
+            return displayStroke;
+        }
+
+        /**
          * In order to improve the user experience, it may be interesting to
          * store the {@code ConstantSolidFillLegend} as a field before removing
          * it. This way, we will be able to use it back directly... unless the

--- a/orbisgis-view/src/main/java/org/orbisgis/view/toc/actions/cui/legends/PnlUniquePointSE.java
+++ b/orbisgis-view/src/main/java/org/orbisgis/view/toc/actions/cui/legends/PnlUniquePointSE.java
@@ -40,6 +40,7 @@ import org.orbisgis.legend.structure.stroke.constant.ConstantPenStroke;
 import org.orbisgis.legend.structure.stroke.constant.ConstantPenStrokeLegend;
 import org.orbisgis.legend.thematic.ConstantFormPoint;
 import org.orbisgis.legend.thematic.constant.UniqueSymbolPoint;
+import org.orbisgis.sif.ComponentUtil;
 import org.orbisgis.sif.UIFactory;
 import org.orbisgis.sif.common.ContainerItemProperties;
 import org.orbisgis.view.toc.actions.cui.LegendContext;
@@ -199,8 +200,11 @@ public class PnlUniquePointSE extends PnlUniqueAreaSE {
                 gbc.gridy = 0;
                 gbc.fill = GridBagConstraints.HORIZONTAL;
                 gbc.anchor = GridBagConstraints.PAGE_START;
-                glob.add(getLineBlock(uniquePoint.getPenStroke(),
-                        I18N.tr("Border settings")), gbc);
+                JPanel lb = getLineBlock(uniquePoint.getPenStroke(),
+                        I18N.tr("Border settings"));
+                ComponentUtil.setFieldState(isStrokeEnabled(), lb);
+
+                glob.add(lb, gbc);
 
                 gbc = new GridBagConstraints();
                 gbc.gridx = 0;


### PR DESCRIPTION
on classifications made on point symbolizers.
