### PR TITLE
Second strategy to solve #477

### DIFF
--- a/orbisgis-view/src/main/java/org/orbisgis/view/toc/actions/cui/legends/PnlAbstractUniqueValue.java
+++ b/orbisgis-view/src/main/java/org/orbisgis/view/toc/actions/cui/legends/PnlAbstractUniqueValue.java
@@ -110,6 +110,7 @@ public abstract class PnlAbstractUniqueValue<U extends LineParameters> extends P
         pm.progressTo(100);
         pm.endTask();
         pm.progressTo(100);
+        postProcess(newRL);
         return newRL;
     }
 


### PR DESCRIPTION
We don't loose the classification panel anymore so its state is not lost.

The diff is quite huge mainly because of an indentation change. Basically, I just store the panel in a private field, nothing more.
