### PR TITLE
Fix Java 6 compatibility issue / failing build

### DIFF
--- a/orbisgis-view/src/main/java/org/orbisgis/view/toc/actions/cui/legends/components/AbsSpinner.java
+++ b/orbisgis-view/src/main/java/org/orbisgis/view/toc/actions/cui/legends/components/AbsSpinner.java
@@ -57,7 +57,7 @@ public abstract class AbsSpinner extends JSpinner {
                 // The new value is the old one minus the wheel rotation
                 // times the spin step.
                 Double newValue = ((Double) getValue())
-                        - e.getPreciseWheelRotation() * getSpinStep();
+                        - e.getWheelRotation() * getSpinStep();
                 // Only update if we are within the given range.
                 if (model.getMaximum().compareTo(newValue) >= 0
                         && model.getMinimum().compareTo(newValue) <= 0) {


### PR DESCRIPTION
`MouseWheelEvent#getPreciseWheelRotation` is only since 1.7.
