### PR TITLE
Improve padding and alignment in the table (#470)

### DIFF
--- a/orbisgis-view/src/main/java/org/orbisgis/view/toc/actions/cui/legends/model/KeyCellRenderer.java
+++ b/orbisgis-view/src/main/java/org/orbisgis/view/toc/actions/cui/legends/model/KeyCellRenderer.java
@@ -14,7 +14,6 @@ import java.util.Locale;
  */
 public class KeyCellRenderer extends TableLaFCellRenderer {
     private NumberFormat formatter;
-    private final MappedLegend symbolizer;
 
     /**
      * Set listener to L&F events
@@ -23,9 +22,8 @@ public class KeyCellRenderer extends TableLaFCellRenderer {
      * @param table Where the listener has to be installed
      * @param type  Default cell renderer for this columnClass
      */
-    public KeyCellRenderer(JTable table, Class<?> type, MappedLegend sym) {
+    public KeyCellRenderer(JTable table, Class<?> type) {
         super(table, type);
-        symbolizer = sym;
         formatter = NumberFormat.getInstance(Locale.getDefault());
         formatter.setGroupingUsed(false);
         formatter.setMaximumFractionDigits(TableModelInterval.DIGITS_NUMBER);
@@ -55,6 +53,7 @@ public class KeyCellRenderer extends TableLaFCellRenderer {
                 lab.setText(formatter.format(value));
             }
         }
+        lab.setHorizontalAlignment(SwingConstants.CENTER);
         return lab;
     }
 

--- a/orbisgis-view/src/main/java/org/orbisgis/view/toc/actions/cui/legends/model/TableModelInterval.java
+++ b/orbisgis-view/src/main/java/org/orbisgis/view/toc/actions/cui/legends/model/TableModelInterval.java
@@ -61,6 +61,7 @@ public class TableModelInterval<U extends LineParameters> extends AbstractLegend
             Double d = getKeyAt(rowIndex);
             SortedSet<Double> tail = ts.tailSet(d);
             StringBuilder sb = new StringBuilder();
+            sb.append("  ");
             if(Double.isInfinite(d)){
                 sb.append("]");
                 sb.append("-").append(Character.toString('\u221e')) ;
@@ -84,7 +85,7 @@ public class TableModelInterval<U extends LineParameters> extends AbstractLegend
                         formatter.format(nd);
                 sb.append(numS);
             }
-            sb.append("[");
+            sb.append("[  ");
             return sb.toString();
         }
         throw new IndexOutOfBoundsException("We did not found a column at index "+columnIndex+" !");

--- a/orbisgis-view/src/main/java/org/orbisgis/view/toc/actions/cui/legends/panels/TablePanel.java
+++ b/orbisgis-view/src/main/java/org/orbisgis/view/toc/actions/cui/legends/panels/TablePanel.java
@@ -125,12 +125,11 @@ public class TablePanel<K, U extends LineParameters> extends JPanel
         previews.setCellEditor(previewCellEditor);
         // We put a default editor on the keys.
         TableColumn keys = table.getColumnModel().getColumn(keyColumnIndex);
-        TableCellEditor ker = keyCellEditor;
         CellEditorListener cel = EventHandler.create(
                 CellEditorListener.class, tableModel, "fireTableDataChanged", null, "editingStopped");
-        ker.addCellEditorListener(cel);
-        keys.setCellEditor(ker);
-        keys.setCellRenderer(new KeyCellRenderer(table, previewClass, legend));
+        keyCellEditor.addCellEditorListener(cel);
+        keys.setCellEditor(keyCellEditor);
+        keys.setCellRenderer(new KeyCellRenderer(table, previewClass));
         JScrollPane jsp = new JScrollPane(table);
 
         // Set the viewport to view 6 rows with a width of 400 pixels.


### PR DESCRIPTION
See #470 for a before screenshot. I made the Threshold (for Interval Classifications) and Value (for Value Classifications) columns center aligned, and added a padding of 2 whitespaces around the intervals in the Label column for Interval Classifications. After:

![table_after](https://f.cloud.github.com/assets/2470768/993207/ba5c708c-0994-11e3-8ea4-56c12c337b1f.png)
