### PR TITLE
Remove gettext-commons-maven-repository

### DIFF
--- a/bundles/orbisgis-omanager-plugin/pom.xml
+++ b/bundles/orbisgis-omanager-plugin/pom.xml
@@ -113,10 +113,4 @@
                     <scope>provided</scope>
                 </dependency>
         </dependencies>
-        <pluginRepositories>
-                <pluginRepository>
-                        <id>gettext-commons-site</id>
-                        <url>http://gettext-commons-maven-repository.googlecode.com/svn/repository</url>
-                </pluginRepository>
-        </pluginRepositories>
 </project>

--- a/bundles/orbisgis-omanager/pom.xml
+++ b/bundles/orbisgis-omanager/pom.xml
@@ -107,10 +107,4 @@
                     <version>0.9.7</version>
                 </dependency>
         </dependencies>
-        <pluginRepositories>
-                <pluginRepository>
-                        <id>gettext-commons-site</id>
-                        <url>http://gettext-commons-maven-repository.googlecode.com/svn/repository</url>
-                </pluginRepository>
-        </pluginRepositories>
 </project>

--- a/bundles/orbisgis-oshell/pom.xml
+++ b/bundles/orbisgis-oshell/pom.xml
@@ -95,17 +95,4 @@
                     <version>1.2.16</version>
                 </dependency>
         </dependencies>
-        <pluginRepositories>
-                <pluginRepository>
-                        <id>gettext-commons-site</id>
-                        <url>http://gettext-commons-maven-repository.googlecode.com/svn/repository</url>
-                </pluginRepository>
-        </pluginRepositories>
-        <repositories>
-                <repository>
-                        <id>gettext-commons-site</id>
-                        <name>gettext</name>
-                        <url>http://gettext-commons-maven-repository.googlecode.com/svn/repository</url>
-                </repository>
-        </repositories>
 </project>

--- a/legend/pom.xml
+++ b/legend/pom.xml
@@ -90,10 +90,4 @@
                         </plugin>
                 </plugins>
         </build>
-        <pluginRepositories>
-                <pluginRepository>
-                        <id>gettext-commons-site</id>
-                        <url>http://gettext-commons-maven-repository.googlecode.com/svn/repository</url>
-                </pluginRepository>
-        </pluginRepositories>
 </project>

--- a/orbisgis-core/pom.xml
+++ b/orbisgis-core/pom.xml
@@ -138,16 +138,4 @@
                         <scope>test</scope>
                 </dependency>
         </dependencies>
-        <pluginRepositories>
-                <pluginRepository>
-                        <id>gettext-commons-site</id>
-                        <url>http://gettext-commons-maven-repository.googlecode.com/svn/repository</url>
-                </pluginRepository>
-        </pluginRepositories>
-        <repositories>
-                <repository>
-                        <id>gettext-commons-site</id>
-                        <url>http://gettext-commons-maven-repository.googlecode.com/svn/repository/</url>
-                </repository>
-        </repositories>    
 </project>

--- a/orbisgis-sif/pom.xml
+++ b/orbisgis-sif/pom.xml
@@ -85,16 +85,4 @@
                         <version>4.2</version>
                 </dependency>
         </dependencies>
-        <repositories>
-                <repository>
-                        <id>gettext-commons-site</id>
-                        <url>http://gettext-commons-maven-repository.googlecode.com/svn/repository/</url>
-                </repository>
-        </repositories>
-        <pluginRepositories>
-                <pluginRepository>
-                        <id>gettext-commons-site</id>
-                        <url>http://gettext-commons-maven-repository.googlecode.com/svn/repository</url>
-                </pluginRepository>
-        </pluginRepositories>
 </project>

--- a/orbisgis-view/pom.xml
+++ b/orbisgis-view/pom.xml
@@ -132,10 +132,4 @@
                     <version>4.2</version>
                 </dependency>
         </dependencies>
-        <pluginRepositories>
-                <pluginRepository>
-                        <id>gettext-commons-site</id>
-                        <url>http://gettext-commons-maven-repository.googlecode.com/svn/repository</url>
-                </pluginRepository>
-        </pluginRepositories>
 </project>


### PR DESCRIPTION
The Transifex Jenkins build was failing because Jenkins couldn't find
the maven-gettext-plugin. Now we compile it on Jenkins and deploy it to
repo.orbisgis.org (as well as gettext-commons), so we don't need this
repository anymore.
