### PR TITLE
Fix SQL function tooltip width to 300px

### DIFF
--- a/orbisgis-view/src/main/java/org/orbisgis/view/sqlconsole/ui/FunctionListRenderer.java
+++ b/orbisgis-view/src/main/java/org/orbisgis/view/sqlconsole/ui/FunctionListRenderer.java
@@ -44,6 +44,8 @@ import org.orbisgis.view.icons.OrbisGISIcon;
 public class FunctionListRenderer extends ListLaFRenderer {
         private static final long serialVersionUID = 1L;
 
+        public static final int TOOLTIP_WIDTH_PX = 300;
+
         public FunctionListRenderer(JList list) {
                 super(list);
         }
@@ -67,8 +69,9 @@ public class FunctionListRenderer extends ListLaFRenderer {
                         FunctionElement sqlFunction = (FunctionElement)value;
                         renderingComp.setIcon(getFunctionIcon(sqlFunction));
                         renderingComp.setText(sqlFunction.getFunctionName());
-                        renderingComp.setToolTipText("<html><body><p style='width: 300px;'>"
-                                + sqlFunction.getToolTip() + "</p></body></html>");
+                        renderingComp.setToolTipText("<html><body><p style='width: "
+                                + TOOLTIP_WIDTH_PX + "px;'>" + sqlFunction.getToolTip()
+                                + "</p></body></html>");
                 }
                 return nativeCell;
         }


### PR DESCRIPTION
This works for all functions except some of the ones in gdms-topology.
See irstv/gdms-topology#67. Fixes #560.
