### PR TITLE
Disable commenting when the text is empty

### DIFF
--- a/orbisgis-view/src/main/java/org/orbisgis/view/beanshell/BshConsolePanel.java
+++ b/orbisgis-view/src/main/java/org/orbisgis/view/beanshell/BshConsolePanel.java
@@ -497,12 +497,16 @@ public final class BshConsolePanel extends JPanel {
                         clearAction.setEnabled(false);
                         saveAction.setEnabled(false);
                         findAction.setEnabled(false);
+                        commentAction.setEnabled(false);
+                        blockCommentAction.setEnabled(false);
                 }
                 else{
                         executeAction.setEnabled(true);
                         clearAction.setEnabled(true);
                         saveAction.setEnabled(true);
                         findAction.setEnabled(true);
+                        commentAction.setEnabled(true);
+                        blockCommentAction.setEnabled(true);
                 }
         }
         

--- a/orbisgis-view/src/main/java/org/orbisgis/view/sqlconsole/ui/SQLConsolePanel.java
+++ b/orbisgis-view/src/main/java/org/orbisgis/view/sqlconsole/ui/SQLConsolePanel.java
@@ -589,6 +589,8 @@ public class SQLConsolePanel extends JPanel {
                         findAction.setEnabled(false);
                         quoteAction.setEnabled(false);
                         unQuoteAction.setEnabled(false);
+                        commentAction.setEnabled(false);
+                        blockCommentAction.setEnabled(false);
                         formatSQLAction.setEnabled(false);
                 }
                 else{
@@ -598,6 +600,8 @@ public class SQLConsolePanel extends JPanel {
                         findAction.setEnabled(true);
                         quoteAction.setEnabled(true);
                         unQuoteAction.setEnabled(true);
+                        commentAction.setEnabled(true);
+                        blockCommentAction.setEnabled(true);
                         formatSQLAction.setEnabled(true);
                 }
         }


### PR DESCRIPTION
Without this, if a user tries to comment a line when the text is empty,
an exception is thrown.

This should have been included in #579.
