### PR TITLE
Fix maven-gettext configuration

### DIFF
--- a/bundles/orbisgis-omanager-plugin/pom.xml
+++ b/bundles/orbisgis-omanager-plugin/pom.xml
@@ -49,7 +49,7 @@
                                 <configuration>
                                         <poDirectory>${project.build.sourceDirectory}/../resources/org/orbisgis/omanager/plugin/translation/</poDirectory>
                                         <targetBundle>org.orbisgis.omanager.plugin.Messages</targetBundle>
-                                        <keywords>-ktr</keywords>
+                                        <keywords>-ktr -kmarktr</keywords>
                                         <outputFormat>properties</outputFormat>
                                 </configuration>
                         </plugin>

--- a/bundles/orbisgis-omanager/pom.xml
+++ b/bundles/orbisgis-omanager/pom.xml
@@ -50,7 +50,7 @@
                                 <configuration>
                                         <poDirectory>${project.build.sourceDirectory}/../resources/org/orbisgis/omanager/translation/</poDirectory>
                                         <targetBundle>org.orbisgis.omanager.Messages</targetBundle>
-                                        <keywords>-ktr</keywords>
+                                        <keywords>-ktr -kmarktr</keywords>
                                         <outputFormat>properties</outputFormat>
                                 </configuration>
                         </plugin>

--- a/bundles/orbisgis-oshell/pom.xml
+++ b/bundles/orbisgis-oshell/pom.xml
@@ -50,7 +50,7 @@
                                 <configuration>
                                         <poDirectory>${project.build.sourceDirectory}/../resources/org/orbisgis/oshell/translation/</poDirectory>
                                         <targetBundle>org.orbisgis.oshell.Messages</targetBundle>
-                                        <keywords>-ktr</keywords>
+                                        <keywords>-ktr -kmarktr</keywords>
                                         <outputFormat>properties</outputFormat>
                                 </configuration>
                         </plugin>

--- a/legend/pom.xml
+++ b/legend/pom.xml
@@ -55,7 +55,7 @@
                                 <configuration>
                                         <poDirectory>${project.build.sourceDirectory}/../resources/org/orbisgis/legend/translation/language/</poDirectory>
                                         <targetBundle>i18n.orbisgis.legend</targetBundle>
-                                        <keywords>-ktr</keywords>
+                                        <keywords>-ktr -kmarktr</keywords>
                                         <outputFormat>properties</outputFormat>
                                 </configuration>
                         </plugin>

--- a/orbisgis-core/pom.xml
+++ b/orbisgis-core/pom.xml
@@ -59,7 +59,7 @@
                                 <configuration>
                                         <poDirectory>${project.build.sourceDirectory}/../resources/org/orbisgis/core/translation/language/</poDirectory>
                                         <targetBundle>org.orbisgis.core.Messages</targetBundle>
-                                        <keywords>-ktr</keywords>
+                                        <keywords>-ktr -kmarktr</keywords>
                                         <outputFormat>properties</outputFormat>
                                 </configuration>
                         </plugin>

--- a/orbisgis-sif/pom.xml
+++ b/orbisgis-sif/pom.xml
@@ -53,7 +53,7 @@
                                 <configuration>
                                         <poDirectory>${project.build.sourceDirectory}/../resources/org/orbisgis/sif/translation/language/</poDirectory>
                                         <targetBundle>org.orbisgis.sif.Messages</targetBundle>
-                                        <keywords>-ktr</keywords>
+                                        <keywords>-ktr -kmarktr</keywords>
                                         <outputFormat>properties</outputFormat>
                                 </configuration>
                         </plugin>

--- a/orbisgis-view/pom.xml
+++ b/orbisgis-view/pom.xml
@@ -38,7 +38,7 @@
                                 <configuration>
                                         <poDirectory>${project.build.sourceDirectory}/../resources/org/orbisgis/view/translation/language/</poDirectory>
                                         <targetBundle>org.orbisgis.view.Messages</targetBundle>
-                                        <keywords>-ktr</keywords>
+                                        <keywords>-ktr -kmarktr</keywords>
                                         <outputFormat>properties</outputFormat>
                                 </configuration>
                         </plugin>


### PR DESCRIPTION
I18N.marktr where misconfigured in pom.xml. Not recognized as translation key.
