### PR TITLE
Fix/jna import

### DIFF
--- a/integration-test/src/test/java/org/orbisgis/itest/BundleTest.java
+++ b/integration-test/src/test/java/org/orbisgis/itest/BundleTest.java
@@ -92,7 +92,7 @@ public class BundleTest {
                 mavenBundle("org.orbisgis", "h2drivers").noStart(),
                 mavenBundle("org.orbisgis", "h2spatial-osgi"),
                 mavenBundle("org.orbisgis", "h2spatial-ext-osgi"),
-                mavenBundle("org.orbisgis", "java-network-analyzer").version("0.1.5"),
+                mavenBundle("org.orbisgis", "java-network-analyzer").version("0.1.6"),
                 mavenBundle("org.jgrapht", "jgrapht-core").version("0.9.0"),
                 mavenBundle("org.orbisgis", "h2network").version("1.0.3-SNAPSHOT").noStart(),
                 junitBundles());


### PR DESCRIPTION
OSGi unit was looking for JNA 0.1.5 in maven central
https://travis-ci.org/irstv/orbisgis/jobs/24976747

```
Running org.orbisgis.itest.BundleTest
47 [main] INFO org.ops4j.pax.exam.spi.DefaultExamSystem - Pax Exam System (Version: 3.3.0) created.
172 [main] INFO org.ops4j.pax.exam.junit.impl.ProbeRunner - creating PaxExam runner for class org.orbisgis.itest.BundleTest
257 [main] INFO org.ops4j.pax.exam.junit.impl.ProbeRunner - running test class org.orbisgis.itest.BundleTest
4033 [main] WARN org.ops4j.pax.url.mvn.internal.AetherBasedResolver - Error resolving artifactorg.orbisgis:java-network-analyzer:jar:0.1.5:Could not find artifact org.orbisgis:java-network-analyzer:jar:0.1.5 in central (http://repo1.maven.org/maven2/)
org.sonatype.aether.resolution.ArtifactResolutionException: Could not find artifact org.orbisgis:java-network-analyzer:jar:0.1.5 in central (http://repo1.maven.org/maven2/)
at org.sonatype.aether.impl.internal.DefaultArtifactResolver.resolve(DefaultArtifactResolver.java:538)
```
