### PR TITLE
Add build date and version in distribution folder

### DIFF
--- a/orbisgis-dist/pom.xml
+++ b/orbisgis-dist/pom.xml
@@ -115,6 +115,8 @@
     </build>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.build.timestamp.format>YYYY-MM-dd</maven.build.timestamp.format>
+        <buildNumber>${maven.build.timestamp}</buildNumber>
     </properties>
     <dependencies>
         <dependency>

--- a/orbisgis-dist/src/main/assembly/bin.xml
+++ b/orbisgis-dist/src/main/assembly/bin.xml
@@ -5,6 +5,7 @@
         <formats>
                 <format>zip</format>
         </formats>
+        <baseDirectory>${artifactId}-${project.version}-${buildNumber}</baseDirectory>
         <fileSets>
                 <fileSet>
                         <directory>${project.basedir}</directory>


### PR DESCRIPTION
The folder in zip is renamed from "orbisgis" to "orbisgis-dist-4.1.0-SNAPSHOT-2014-05-13"
