### PR TITLE
Import javax.swing.event in legend, as the EventHandler use it in legend

### DIFF
--- a/bundles/toc/pom.xml
+++ b/bundles/toc/pom.xml
@@ -38,8 +38,8 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Private-Package>org.orbisgis.toc.*</Private-Package>
-                        <Public-Package>org.orbisgis.toc</Public-Package>
+                        <Private-Package>org.orbisgis.view.toc.translation.*</Private-Package>
+                        <Public-Package>org.orbisgis.view.toc.*</Public-Package>
                         <Service-Component>OSGI-INF/service-component/*.xml</Service-Component>
                     </instructions>
                 </configuration>
@@ -59,7 +59,7 @@
                 <artifactId>gettext-maven-plugin</artifactId>
                 <configuration>
                     <poDirectory>src/main/resources/org/orbisgis/view/toc/</poDirectory>
-                    <targetBundle>org.orbisgis.toc.Messages</targetBundle>
+                    <targetBundle>org.orbisgis.view.toc.translation.Messages</targetBundle>
                     <keywords>-ktr</keywords>
                     <outputFormat>properties</outputFormat>
                 </configuration>

--- a/bundles/toc/src/main/resources/org/orbisgis/view/toc/i18n.properties
+++ b/bundles/toc/src/main/resources/org/orbisgis/view/toc/i18n.properties
@@ -27,4 +27,4 @@
 # info_at_ orbisgis.org
 #
 
-basename=org.orbisgis.toc.Messages
+basename=org.orbisgis.view.toc.translation.Messages

--- a/legend/pom.xml
+++ b/legend/pom.xml
@@ -54,6 +54,7 @@
                                 <Public-Package>org.orbisgis.legend.*</Public-Package>
                                 <Private-Package>org.orbisgis.legend.translation</Private-Package>
                                 <Service-Component>OSGI-INF/service-component/*.xml</Service-Component>
+                                <Import-Package>javax.swing.event, *</Import-Package>
                             </instructions>
                         </configuration>
                     </plugin>

--- a/orbisgis-dist/pom.xml
+++ b/orbisgis-dist/pom.xml
@@ -234,12 +234,5 @@
             <version>${parent.version}</version>
             <scope>provided</scope>
         </dependency>
-        <!-- scala-library 2.9.2 is not OSGi ready, import it in old-fashion way -->
-        <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-            <version>2.11.1</version>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
About exception Caused by: java.lang.NoClassDefFoundError: javax.swing.event.ChangeEvent not found by org.orbisgis.legend [41]
