### PR TITLE
Select current directory if no folder is selected [SIF]

### DIFF
--- a/orbisgis-sif/src/main/java/org/orbisgis/sif/components/OpenFolderPanel.java
+++ b/orbisgis-sif/src/main/java/org/orbisgis/sif/components/OpenFolderPanel.java
@@ -28,10 +28,12 @@
  */
 package org.orbisgis.sif.components;
 
+import org.orbisgis.sif.UIFactory;
+
+import javax.swing.*;
+import javax.swing.filechooser.FileFilter;
 import java.io.File;
 import java.net.URL;
-import javax.swing.filechooser.FileFilter;
-import org.orbisgis.sif.UIFactory;
 
 /**
  * This class handles the panel used to import the content of a folder in the
@@ -71,6 +73,16 @@ public class OpenFolderPanel extends AbstractOpenPanel {
                 } else {
                         return null;
                 }
+        }
+
+        @Override
+        public File getSelectedFile() {
+            final JFileChooser fileChooser = getFileChooser();
+            File selectedFile = fileChooser.getSelectedFile();
+            if (selectedFile == null) {
+                selectedFile = fileChooser.getCurrentDirectory();
+            }
+            return selectedFile;
         }
 
         @Override


### PR DESCRIPTION
Here I correct a problem that has been annoying me for quite some time.
When selecting a folder to add/import, if no folder was highlighted, we
got the `sif.folderMustBeSelected` error.

Now, we just add/import the current directory if no folder is
highlighted.
