### PR TITLE
Fix import/link file to table name

### DIFF
--- a/bundles/core-jdbc/src/main/java/org/orbisgis/corejdbc/internal/DataManagerImpl.java
+++ b/bundles/core-jdbc/src/main/java/org/orbisgis/corejdbc/internal/DataManagerImpl.java
@@ -116,7 +116,7 @@ public class DataManagerImpl implements DataManager {
             if(!path.exists()) {
                 throw new SQLException("Specified source does not exists");
             }
-            String tableName = findUniqueTableName(FileUtils.getNameFromURI(uri).toUpperCase());
+            String tableName = findUniqueTableName(TableLocation.capsIdentifier(FileUtils.getNameFromURI(uri), isH2));
             try (Connection connection = dataSource.getConnection()) {
                 // Find if a linked table use this file path
                 DatabaseMetaData meta = connection.getMetaData();
@@ -139,7 +139,7 @@ public class DataManagerImpl implements DataManager {
                 // TODO if tcp, use DriverManager
                 PreparedStatement st = connection.prepareStatement("CALL FILE_TABLE(?,?)");
                 st.setString(1, path.getAbsolutePath());
-                st.setString(2, tableName);
+                st.setString(2, new TableLocation("","",tableName).toString(isH2));
                 st.execute();
             }
             return tableName;

--- a/orbisgis-view/src/main/java/org/orbisgis/view/geocatalog/jobs/ImportFiles.java
+++ b/orbisgis-view/src/main/java/org/orbisgis/view/geocatalog/jobs/ImportFiles.java
@@ -85,8 +85,8 @@ public class ImportFiles implements BackgroundJob {
                 String ext = FilenameUtils.getExtension(file.getName());
                 DriverFunction driverFunction = driverFunctionContainer.getDriverFromExt(ext, driverType);
                 if(driverFunction != null) {
-                    TableLocation tableName = TableLocation.parse(dataManager.findUniqueTableName(
-                            FileUtils.getNameFromURI(file.toURI())), isH2);
+                    TableLocation tableName = new TableLocation("","",dataManager.findUniqueTableName(
+                            TableLocation.capsIdentifier(FileUtils.getNameFromURI(file.toURI()), isH2)));
                     driverFunction.importFile(connection, tableName.toString() ,file, new H2GISProgressMonitor(filePm));
                 } else {
                     LOGGER.error(I18N.tr("No driver found for {0} extension", ext));


### PR DESCRIPTION
If a file name contains a dot then do not define a schema, use quoted table name instead
