### PR TITLE
PostGIS driver class compatible with H2 Linked Table

### DIFF
--- a/bundles/postgis-jts-osgi/src/main/java/org/orbisgis/postgis_jts_osgi/Driver.java
+++ b/bundles/postgis-jts-osgi/src/main/java/org/orbisgis/postgis_jts_osgi/Driver.java
@@ -9,6 +9,9 @@ import java.util.logging.Level;
 
 /**
  * Driver that provide directly the JTS Object when calling {@link java.sql.ResultSet#getObject(int)}
+ * To create linked table on H2 database to PostGIS db:
+ * CREATE LINKED TABLE mytable('org.orbisgis.postgis_jts_osgi.Driver',
+ * 'jdbc:postgresql_h2://serverdomain:5432/databasename', 'user', 'password', '(select * from mytable)');
  * @author Nicolas Fortin
  */
 public class Driver extends JtsWrapper {


### PR DESCRIPTION
Add postgre driver compatible with h2 linked table (for geometry columns)
