### PR TITLE
RowSet rework

### DIFF
--- a/bundles/core-jdbc/pom.xml
+++ b/bundles/core-jdbc/pom.xml
@@ -124,6 +124,12 @@
             <version>${sl4j-version}</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${sl4j-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.orbisgis</groupId>
             <artifactId>h2drivers</artifactId>
             <version>${h2-gis-version}</version>

--- a/bundles/core-jdbc/src/main/java/org/orbisgis/corejdbc/ReadRowSet.java
+++ b/bundles/core-jdbc/src/main/java/org/orbisgis/corejdbc/ReadRowSet.java
@@ -7,6 +7,7 @@ import javax.sql.rowset.JdbcRowSet;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Set;
+import java.util.SortedSet;
 import java.util.concurrent.locks.Lock;
 
 /**
@@ -46,20 +47,6 @@ public interface ReadRowSet extends JdbcRowSet , SpatialResultSet {
     public String getPkName();
 
     /**
-     * @param primaryKeyRowValue The {@link #getPkName()} value of a row
-     * @return Corresponding {@link #getRow()} value or null if there is no such object in the table.
-     * @see #getRowPK(int)
-     */
-    public int getRowId(Object primaryKeyRowValue);
-
-    /**
-     * @param rowNumber Table row number [1-n]
-     * @return Cached row primary key
-     * @see #getRowId(Object)
-     */
-    public long getRowPK(int rowNumber);
-
-    /**
      * @return The read lock on this result set
      */
     Lock getReadLock();
@@ -80,4 +67,16 @@ public interface ReadRowSet extends JdbcRowSet , SpatialResultSet {
      * @return The number of rows return by using next() from beforeFirst()
      */
     long getFilteredRowCount() throws SQLException;
+
+    /**
+     * @return The numeric, simple primary key of the current row. Used to identify a row.
+     */
+    long getPk() throws SQLException;
+
+    /**
+     * Fetch row number using primary key values.
+     * @param pkSet Primary key set {@link #getPk()}
+     * @return Row identifier set {@link #getRow()}
+     */
+    SortedSet<Integer> getRowNumberFromRowPk(SortedSet<Long> pkSet) throws SQLException;
 }

--- a/bundles/core-jdbc/src/main/java/org/orbisgis/corejdbc/ReadRowSet.java
+++ b/bundles/core-jdbc/src/main/java/org/orbisgis/corejdbc/ReadRowSet.java
@@ -58,17 +58,6 @@ public interface ReadRowSet extends JdbcRowSet , SpatialResultSet {
     void setCloseDelay(int milliseconds);
 
     /**
-     * Filter row id in order to return only theses rows. Values returned by {@link #getRow()} are unchanged.
-     * @param rowIdSet Row number [1-n] to keep
-     */
-    void setFilter(Collection<Integer> rowIdSet);
-
-    /**
-     * @return The number of rows return by using next() from beforeFirst()
-     */
-    long getFilteredRowCount() throws SQLException;
-
-    /**
      * @return The numeric, simple primary key of the current row. Used to identify a row.
      */
     long getPk() throws SQLException;

--- a/bundles/core-jdbc/src/main/java/org/orbisgis/corejdbc/ReadTable.java
+++ b/bundles/core-jdbc/src/main/java/org/orbisgis/corejdbc/ReadTable.java
@@ -37,6 +37,8 @@ import org.h2gis.utilities.TableLocation;
 import org.orbisgis.corejdbc.DataManager;
 import org.orbisgis.corejdbc.ReadRowSet;
 import org.orbisgis.commons.progress.ProgressMonitor;
+import org.orbisgis.corejdbc.common.IntegerUnion;
+import org.orbisgis.corejdbc.common.LongUnion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
@@ -53,6 +55,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.text.NumberFormat;
 import java.util.*;
+import java.util.concurrent.locks.Lock;
 
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 
@@ -146,6 +149,15 @@ public class ReadTable {
             }
             return columnValues;
         }
+    }
+
+    public static SortedSet<Long> getRowPkFromRowNumber(ReadRowSet rowSet, SortedSet<Integer> rowNumber) throws SQLException {
+        SortedSet<Long> modelRows = new LongUnion();
+        for (int rowNum : rowNumber) {
+            rowSet.absolute(rowNum);
+            modelRows.add(rowSet.getPk());
+        }
+        return modelRows;
     }
 
     public static long getRowCount(Connection connection, String tableReference) throws SQLException {

--- a/bundles/core-jdbc/src/main/java/org/orbisgis/corejdbc/internal/ReadRowSetImpl.java
+++ b/bundles/core-jdbc/src/main/java/org/orbisgis/corejdbc/internal/ReadRowSetImpl.java
@@ -349,18 +349,19 @@ public class ReadRowSetImpl extends AbstractRowSet implements JdbcRowSet, DataSo
                         if (targetBatch >= rowFetchFirstPk.size() || (targetBatch != 0 && rowFetchFirstPk.get(targetBatch) == null)) {
                             // For optimisation sake
                             // Like binary search if the gap of target batch is too wide, require average PK values
-                            final int batchCount = (int)(getRowCount() / fetchSize);
-                            int middleBatch = batchCount / 2;
+                            int topBatchCount = (int)(getRowCount() / fetchSize);
+                            int middleBatch = topBatchCount / 2;
                             while(targetBatch < middleBatch) {
+                                topBatchCount = middleBatch;
                                 middleBatch = middleBatch / 2;
                             }
                             fetchBatchPk(middleBatch);
                             int intermediateBatchFetching = 1;
-                            middleBatch = middleBatch + (batchCount - middleBatch) / 2;
+                            middleBatch = middleBatch + (topBatchCount - middleBatch) / 2;
                             while(targetBatch > middleBatch && intermediateBatchFetching < MAX_INTERMEDIATE_BATCH) {
                                 fetchBatchPk(middleBatch);
                                 intermediateBatchFetching++;
-                                middleBatch = middleBatch + (batchCount - middleBatch) / 2;
+                                middleBatch = middleBatch + (topBatchCount - middleBatch) / 2;
                             }
                             fetchBatchPk(targetBatch);
                         }

--- a/bundles/core-jdbc/src/main/java/org/orbisgis/corejdbc/internal/ReadRowSetImpl.java
+++ b/bundles/core-jdbc/src/main/java/org/orbisgis/corejdbc/internal/ReadRowSetImpl.java
@@ -646,7 +646,7 @@ public class ReadRowSetImpl extends AbstractRowSet implements JdbcRowSet, DataSo
         LRUMap<Long, Object[]> lruMap = new LRUMap<>(fetchSize + 1);
         lruMap.putAll(cache);
         cache = lruMap;
-        rowFetchFirstPk.clear();
+        rowFetchFirstPk = new ArrayList<>(Arrays.asList(new Long[]{null}));
         currentBatch.clear();
         currentBatchId = -1;
     }
@@ -697,8 +697,8 @@ public class ReadRowSetImpl extends AbstractRowSet implements JdbcRowSet, DataSo
             moveCursorTo(rowId);
             currentRow = null;
             cache.clear();
-            rowFetchFirstPk.clear();
-            currentBatch.clear();
+            rowFetchFirstPk = new ArrayList<>(Arrays.asList(new Long[]{null}));
+            currentBatch = new ArrayList<>(fetchSize + 1);
             currentBatchId = -1;
             if(res.getResultSet().getRow() > 0 && !res.getResultSet().isAfterLast()) {
                 res.getResultSet().refreshRow();

--- a/bundles/core-jdbc/src/main/java/org/orbisgis/corejdbc/internal/ReadRowSetImpl.java
+++ b/bundles/core-jdbc/src/main/java/org/orbisgis/corejdbc/internal/ReadRowSetImpl.java
@@ -50,7 +50,6 @@ import org.xnap.commons.i18n.I18nFactory;
 import javax.sql.DataSource;
 import javax.sql.rowset.JdbcRowSet;
 import javax.sql.rowset.RowSetWarning;
-import javax.swing.plaf.nimbus.State;
 import java.beans.EventHandler;
 import java.beans.PropertyChangeListener;
 import java.io.InputStream;

--- a/bundles/core-jdbc/src/test/java/org/orbisgis/corejdbc/RowSetTest.java
+++ b/bundles/core-jdbc/src/test/java/org/orbisgis/corejdbc/RowSetTest.java
@@ -282,7 +282,7 @@ public class RowSetTest {
                 Statement st = connection.createStatement()) {
             st.execute("drop table if exists test");
             st.execute("create table test (id integer primary key, y float) as select X * 10 id, SQRT(X) y from " +
-                    "SYSTEM_RANGE(1, 50)");
+                    "SYSTEM_RANGE(1, 120)");
             rs.setCommand("SELECT * FROM TEST");
             rs.execute();
             assertEquals(new TreeSet<>(Arrays.asList(1, 5, 10)), rs.getRowNumberFromRowPk(new TreeSet<>(Arrays.asList

--- a/bundles/core-jdbc/src/test/java/org/orbisgis/corejdbc/RowSetTest.java
+++ b/bundles/core-jdbc/src/test/java/org/orbisgis/corejdbc/RowSetTest.java
@@ -242,15 +242,24 @@ public class RowSetTest {
             st.execute("create table test (id integer primary key, y float) as select X, SQRT(X::float) SQ from SYSTEM_RANGE(1, 2000)");
             rs.setCommand("SELECT * FROM TEST");
             rs.execute();
-            // First Test forward access mode
+            // Test forward access mode
             for(int i =0; i < 2000; i++) {
                 assertTrue(rs.next());
                 assertEquals(i+1, rs.getInt("ID"));
                 assertEquals(Math.sqrt(i+1), rs.getDouble(2), 1e-6);
             }
             assertFalse(rs.next());
+
             rs.refreshRow();
-            // Second test backward access mode
+            // Test Random access mode
+            for(int i : Arrays.asList(ReadRowSetImpl.DEFAULT_FETCH_SIZE + 1, 500, 800, 15, 1850)) {
+                assertTrue(rs.absolute(i + 1));
+                assertEquals(i+1, rs.getInt("ID"));
+                assertEquals(Math.sqrt(i+1), rs.getDouble(2), 1e-6);
+            }
+
+            rs.refreshRow();
+            // Test backward access mode
             rs.afterLast();
             for(int i = 1999; i >= 0; i--) {
                 assertTrue(rs.previous());
@@ -258,13 +267,6 @@ public class RowSetTest {
                 assertEquals(Math.sqrt(i+1), rs.getDouble(2), 1e-6);
             }
             assertFalse(rs.previous());
-            rs.refreshRow();
-            // Third test Random access mode
-            for(int i : Arrays.asList(50, 500, 800, 15, 1850)) {
-                assertTrue(rs.absolute(i + 1));
-                assertEquals(i+1, rs.getInt("ID"));
-                assertEquals(Math.sqrt(i+1), rs.getDouble(2), 1e-6);
-            }
         }
     }
 

--- a/bundles/core-jdbc/src/test/java/org/orbisgis/corejdbc/RowSetTest.java
+++ b/bundles/core-jdbc/src/test/java/org/orbisgis/corejdbc/RowSetTest.java
@@ -268,7 +268,7 @@ public class RowSetTest {
             TableLocation table = TableLocation.parse("TEST");
             try (ReadRowSetImpl rs = new ReadRowSetImpl(dataSource)) {
                 //rs.initialize(table, "id",new NullProgressMonitor());
-                rs.setCommand("SELECT * FROM TEST ORDER BY flt");
+                rs.setCommand("SELECT * FROM TEST");
                 rs.execute();
                 rs.setFilter(Arrays.asList(1, 3, 4));
                 rs.beforeFirst();

--- a/bundles/core-jdbc/src/test/java/org/orbisgis/corejdbc/RowSetTest.java
+++ b/bundles/core-jdbc/src/test/java/org/orbisgis/corejdbc/RowSetTest.java
@@ -249,6 +249,7 @@ public class RowSetTest {
                 assertEquals(Math.sqrt(i+1), rs.getDouble(2), 1e-6);
             }
             assertFalse(rs.next());
+            rs.refreshRow();
             // Second test backward access mode
             rs.afterLast();
             for(int i = 1999; i >= 0; i--) {
@@ -257,6 +258,7 @@ public class RowSetTest {
                 assertEquals(Math.sqrt(i+1), rs.getDouble(2), 1e-6);
             }
             assertFalse(rs.previous());
+            rs.refreshRow();
             // Third test Random access mode
             for(int i : Arrays.asList(50, 500, 800, 15, 1850)) {
                 assertTrue(rs.absolute(i + 1));

--- a/bundles/core-jdbc/src/test/java/org/orbisgis/corejdbc/RowSetTest.java
+++ b/bundles/core-jdbc/src/test/java/org/orbisgis/corejdbc/RowSetTest.java
@@ -273,6 +273,7 @@ public class RowSetTest {
     /**
      * @throws SQLException
      */
+    @Test
     public void testRowNumExtraction() throws SQLException {
 
         DataManager factory = new DataManagerImpl(dataSource);
@@ -280,7 +281,7 @@ public class RowSetTest {
         try (Connection connection = dataSource.getConnection();
                 Statement st = connection.createStatement()) {
             st.execute("drop table if exists test");
-            st.execute("create table test (id integer primary key, y float) as select X * 10 id from " +
+            st.execute("create table test (id integer primary key, y float) as select X * 10 id, SQRT(X) y from " +
                     "SYSTEM_RANGE(1, 50)");
             rs.setCommand("SELECT * FROM TEST");
             rs.execute();

--- a/bundles/core-jdbc/src/test/java/org/orbisgis/corejdbc/RowSetTest.java
+++ b/bundles/core-jdbc/src/test/java/org/orbisgis/corejdbc/RowSetTest.java
@@ -49,6 +49,7 @@ import java.util.Collections;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -262,6 +263,27 @@ public class RowSetTest {
                 assertEquals(i+1, rs.getInt("ID"));
                 assertEquals(Math.sqrt(i+1), rs.getDouble(2), 1e-6);
             }
+        }
+    }
+
+    /**
+     * @throws SQLException
+     */
+    public void testRowNumExtraction() throws SQLException {
+
+        DataManager factory = new DataManagerImpl(dataSource);
+        ReadRowSet rs = factory.createReadRowSet();
+        try (Connection connection = dataSource.getConnection();
+                Statement st = connection.createStatement()) {
+            st.execute("drop table if exists test");
+            st.execute("create table test (id integer primary key, y float) as select X * 10 id from " +
+                    "SYSTEM_RANGE(1, 50)");
+            rs.setCommand("SELECT * FROM TEST");
+            rs.execute();
+            assertEquals(new TreeSet<>(Arrays.asList(1, 5, 10)), rs.getRowNumberFromRowPk(new TreeSet<>(Arrays.asList
+                    (10l, 50l, 100l))));
+            assertEquals(new TreeSet<>(Arrays.asList(1, 50)), rs.getRowNumberFromRowPk(new TreeSet<>(Arrays
+                    .asList(10l, 500l))));
         }
     }
 

--- a/bundles/core-map/src/main/java/org/orbisgis/coremap/renderer/Renderer.java
+++ b/bundles/core-map/src/main/java/org/orbisgis/coremap/renderer/Renderer.java
@@ -188,7 +188,7 @@ public abstract class Renderer {
                             ProgressMonitor rowSetProgress;
                             // Read row count for progress monitor
                             if(rs instanceof ReadRowSet) {
-                                rowSetProgress = rulesProgress.startTask("Drawing " + layer.getName() + " (Rule " + r.getName() + ")", ((ReadRowSet) rs).getFilteredRowCount());
+                                rowSetProgress = rulesProgress.startTask("Drawing " + layer.getName() + " (Rule " + r.getName() + ")", ((ReadRowSet) rs).getRowCount());
                             } else {
                                 rowSetProgress = rulesProgress.startTask("Drawing " + layer.getName() + " (Rule " + r.getName() + ")", 1);
                             }

--- a/bundles/map-editor/src/main/java/org/orbisgis/mapeditor/map/CachedResultSetContainer.java
+++ b/bundles/map-editor/src/main/java/org/orbisgis/mapeditor/map/CachedResultSetContainer.java
@@ -29,9 +29,6 @@
 package org.orbisgis.mapeditor.map;
 
 import com.vividsolutions.jts.geom.Envelope;
-
-import java.beans.EventHandler;
-import java.beans.PropertyChangeListener;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -41,12 +38,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import com.vividsolutions.jts.geom.GeometryFactory;
 import org.h2gis.utilities.JDBCUtilities;
-import org.h2gis.utilities.SFSUtilities;
 import org.h2gis.utilities.SpatialResultSet;
 import org.h2gis.utilities.TableLocation;
-import org.orbisgis.corejdbc.DataManager;
 import org.orbisgis.corejdbc.MetaData;
 import org.orbisgis.corejdbc.ReadRowSet;
 import org.orbisgis.coremap.layerModel.ILayer;
@@ -63,6 +57,7 @@ import org.xnap.commons.i18n.I18nFactory;
  * @author Nicolas Fortin
  */
 public class CachedResultSetContainer implements ResultSetProviderFactory {
+    private final Map<String, ReadRowSet> cache = new HashMap<>();
     private static final int LOCK_TIMEOUT = 10;
     private static final int FETCH_SIZE = 50;
     private static I18n I18N = I18nFactory.getI18n(CachedResultSetContainer.class);
@@ -84,20 +79,32 @@ public class CachedResultSetContainer implements ResultSetProviderFactory {
         try {
             if(lock.tryLock(WAIT_FOR_INITIALISATION_TIMEOUT, TimeUnit.MILLISECONDS)) {
                 boolean isH2;
-                String integerPK; // Not system PK
+                String integerPK = ""; // Not system PK
                 String tableRef;
-                String geometryField;
                 try (Connection connection = layer.getDataManager().getDataSource().getConnection()) {
                     isH2 = JDBCUtilities.isH2DataBase(connection.getMetaData());
                     tableRef = TableLocation.parse(layer.getTableReference(), isH2).toString(isH2);
-                    integerPK = MetaData.getPkName(connection, tableRef, true);
-                    geometryField = SFSUtilities.getGeometryFields(connection, TableLocation.parse(tableRef)).get(0);
+                    integerPK = MetaData.getPkName(connection, tableRef, false);
                 }
                 if(!isH2) {
                     // Always use cursor with PostGIS
                     return defaultFactory.getResultSetProvider(layer, pm);
                 }
-                return new CachedResultSet(tableRef, integerPK, layer.getDataManager(), geometryField, isH2);
+                ReadRowSet readRowSet = cache.get(tableRef);
+                ResultSetProvider defaultResultSetProvider = defaultFactory.getResultSetProvider(layer, pm);
+                if (readRowSet == null) {
+                    readRowSet = layer.getDataManager().createReadRowSet();
+                    // If the used PK is hidden (because it is system pk)
+                    if(integerPK.isEmpty()) {
+                        readRowSet.setCommand("SELECT " + defaultResultSetProvider.getPkName() + ", * FROM "+tableRef);
+                    }
+                    readRowSet.setFetchSize(FETCH_SIZE);
+                    readRowSet.setCloseDelay(ROWSET_FREE_DELAY);
+                    readRowSet.setFetchDirection(ResultSet.FETCH_FORWARD);
+                    readRowSet.initialize(tableRef, integerPK, pm);
+                    cache.put(tableRef, readRowSet);
+                }
+                return new CachedResultSet(readRowSet, tableRef, layer.getEnvelope(),defaultResultSetProvider);
             } else {
                 throw new SQLException("Cannot draw until layer data source is not initialized");
             }
@@ -109,7 +116,10 @@ public class CachedResultSetContainer implements ResultSetProviderFactory {
     }
 
     public void clearCache() {
-
+        for(ReadRowSet rowSet : cache.values()) {
+            rowSet.setCloseDelay(0);
+        }
+        cache.clear();
     }
 
     /**
@@ -117,25 +127,32 @@ public class CachedResultSetContainer implements ResultSetProviderFactory {
      * @param tableReference table identifier
      */
     public void removeCache(String tableReference) {
-
+        if(!cache.containsKey(tableReference)) {
+            // Try with removing public schema
+            if(TableLocation.parse(tableReference).getSchema().equalsIgnoreCase("public")) {
+                tableReference = TableLocation.parse(tableReference).getTable();
+            }
+        }
+        ReadRowSet removedCache = cache.remove(tableReference);
+        if(removedCache != null) {
+            removedCache.setCloseDelay(0);
+        }
     }
 
     private static class CachedResultSet implements ResultSetProvider {
-        private String tableReference;
-        private String pkName;
         private ReadRowSet readRowSet;
-        private DataManager dataManager;
-        private String geometryField;
-        private PropertyChangeListener cancelListener;
-        private boolean isH2;
+        private String tableReference;
+        private Lock lock;
+        private Envelope tableEnvelope;
+        private ResultSetProvider resultSetProvider;
+        private String pkName;
 
-        public CachedResultSet(String tableReference, String pkName, DataManager dataManager, String geometryField,
-                               boolean isH2) {
+        private CachedResultSet(ReadRowSet readRowSet, String tableReference, Envelope tableEnvelope, ResultSetProvider resultSetProvider) {
+            this.readRowSet = readRowSet;
             this.tableReference = tableReference;
-            this.pkName = pkName;
-            this.dataManager = dataManager;
-            this.geometryField = geometryField;
-            this.isH2 = isH2;
+            this.tableEnvelope = tableEnvelope;
+            this.resultSetProvider = resultSetProvider;
+            this.pkName = resultSetProvider.getPkName();
         }
 
         @Override
@@ -145,21 +162,30 @@ public class CachedResultSetContainer implements ResultSetProviderFactory {
 
         @Override
         public SpatialResultSet execute(ProgressMonitor pm, Envelope extent) throws SQLException {
-            readRowSet = dataManager.createReadRowSet();
-            readRowSet.setFetchSize(FETCH_SIZE);
-            readRowSet.setCloseDelay(ROWSET_FREE_DELAY);
-            readRowSet.setFetchDirection(ResultSet.FETCH_FORWARD);
-            readRowSet.setCommand("select * from " + tableReference + " WHERE " +
-                    TableLocation.capsIdentifier(geometryField, isH2) + " && ?");
-            readRowSet.setObject(1, new GeometryFactory().toGeometry(extent));
-            cancelListener = EventHandler.create(PropertyChangeListener.class, readRowSet, "cancel");
-            readRowSet.initialize(tableReference, pkName, pm);
-            return readRowSet;
+            lock = readRowSet.getReadLock();
+            try {
+                lock.tryLock(LOCK_TIMEOUT, TimeUnit.SECONDS);
+                // Do intersection of envelope
+                double intersectionPercentage = extent.intersection(tableEnvelope).getArea() / tableEnvelope.getArea();
+                // If there is quite no zoom is great use the "select * from table" cached query.
+                if( intersectionPercentage > RATIONAL_USAGE_INDEX) {
+                    readRowSet.beforeFirst();
+                    return readRowSet;
+                } else {
+                    return resultSetProvider.execute(pm, extent);
+                }
+            } catch (InterruptedException ex) {
+                throw new SQLException(I18N.tr("Lock timeout while fetching {0}, another job is using this resource.",
+                        tableReference));
+            }
         }
 
         @Override
         public void close() throws SQLException {
-            readRowSet.close();
+            if(lock != null) {
+                lock.unlock();
+            }
+            resultSetProvider.close();
         }
     }
 }

--- a/bundles/map-editor/src/main/java/org/orbisgis/mapeditor/map/tool/ToolManager.java
+++ b/bundles/map-editor/src/main/java/org/orbisgis/mapeditor/map/tool/ToolManager.java
@@ -694,20 +694,16 @@ public class ToolManager implements MouseListener,MouseWheelListener,MouseMotion
                 Lock readLock = activeLayerRowSet.getReadLock();
                 try {
                     if(readLock.tryLock(TRY_LOCK_TIME, TimeUnit.MILLISECONDS)) {
-                        // Fetch row num using selected pk
-                        SortedSet<Integer> modelRows = new IntegerUnion();
-                        for (long value : selection) {
-                            modelRows.add(activeLayerRowSet.getRowId(value));
-                        }
-                        activeLayerRowSet.setFilter(modelRows);
                         activeLayerRowSet.beforeFirst();
                         while (activeLayerRowSet.next()){
-                            Primitive p;
-                            Geometry geometry = activeLayerRowSet.getGeometry();
-                            if (geometry != null) {
-                                p = new Primitive(geometry, activeLayerRowSet.getLong(activeLayerRowSet.getPkName()));
-                                Handler[] handlers = p.getHandlers();
-                                currentHandlers.addAll(Arrays.asList(handlers));
+                            if(selection.contains(activeLayerRowSet.getPk())) {
+                                Primitive p;
+                                Geometry geometry = activeLayerRowSet.getGeometry();
+                                if (geometry != null) {
+                                    p = new Primitive(geometry, activeLayerRowSet.getPk());
+                                    Handler[] handlers = p.getHandlers();
+                                    currentHandlers.addAll(Arrays.asList(handlers));
+                                }
                             }
                         }
                     }

--- a/bundles/table-editor/src/main/java/org/orbisgis/tablegui/api/TableEditableElement.java
+++ b/bundles/table-editor/src/main/java/org/orbisgis/tablegui/api/TableEditableElement.java
@@ -14,7 +14,6 @@ public interface TableEditableElement extends EditableSource {
     // Properties names
     public static final String PROP_SELECTION = "selection";
 
-
     /**
      * @return Primary keys of the selected rows in the table
      */
@@ -25,15 +24,4 @@ public interface TableEditableElement extends EditableSource {
      * @param selection Row's id
      */
     public void setSelection(Set<Long> selection);
-
-    /**
-     * @return Row number [1-n] of the selected rows
-     */
-    public SortedSet<Integer> getSelectionTableRow() throws EditableElementException;
-
-    /**
-     * Update selection using row number.
-     * @param selection Row number [1-n] of the selected rows
-     */
-    public void setSelectionTableRow(SortedSet<Integer> selection) throws EditableElementException;
 }

--- a/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/TableEditableElementImpl.java
+++ b/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/TableEditableElementImpl.java
@@ -33,15 +33,14 @@ import java.util.Set;
 import java.util.SortedSet;
 
 import org.orbisgis.corejdbc.DataManager;
-import org.orbisgis.corejdbc.common.IntegerUnion;
 import org.orbisgis.corejdbc.common.LongUnion;
 import org.orbisgis.editorjdbc.EditableSourceImpl;
-import org.orbisgis.sif.edition.EditableElementException;
 import org.orbisgis.tablegui.api.TableEditableElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
+
 
 /**
  * Interface to be implemented by those EditableElements that need to be edited
@@ -84,24 +83,6 @@ public class TableEditableElementImpl extends EditableSourceImpl implements Tabl
         @Override
         public SortedSet<Long> getSelection() {
             return Collections.unmodifiableSortedSet(selectedGeometries);
-        }
-
-        @Override
-        public void setSelectionTableRow(SortedSet<Integer> selection) throws EditableElementException {
-            SortedSet<Long> modelRows = new LongUnion();
-            for(int rowNum : selection) {
-                modelRows.add(getRowSet().getRowPK(rowNum));
-            }
-            setSelection(modelRows);
-        }
-
-        @Override
-        public SortedSet<Integer> getSelectionTableRow() throws EditableElementException {
-            SortedSet<Integer> modelRows = new IntegerUnion();
-            for (long value : selectedGeometries) {
-                modelRows.add(getRowSet().getRowId(value));
-            }
-            return modelRows;
         }
 
         @Override

--- a/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/TableEditor.java
+++ b/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/TableEditor.java
@@ -65,6 +65,7 @@ import org.h2gis.utilities.TableLocation;
 import org.orbisgis.commons.progress.SwingWorkerPM;
 import org.orbisgis.corejdbc.DataManager;
 import org.orbisgis.corejdbc.MetaData;
+import org.orbisgis.corejdbc.ReadTable;
 import org.orbisgis.corejdbc.TableEditEvent;
 import org.orbisgis.corejdbc.TableEditListener;
 import org.orbisgis.corejdbc.common.IntegerUnion;
@@ -1262,4 +1263,5 @@ public class TableEditor extends JPanel implements EditorDockable, SourceTable,T
             return true;
         }
     }
+
 }

--- a/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/TableEditor.java
+++ b/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/TableEditor.java
@@ -223,13 +223,13 @@ public class TableEditor extends JPanel implements EditorDockable, SourceTable,T
                 if (!onUpdateEditableSelection.getAndSet(true)) {
                     // Convert primary key value into row number
                     try {
-                        SortedSet<Integer> modelRows = tableEditableElement.getSelectionTableRow();
+                        SortedSet<Integer> modelRows = tableEditableElement.getRowSet().getRowNumberFromRowPk(tableEditableElement.getSelection());
                         setRowSelection(modelRows, -1);
                         if(!modelRows.isEmpty()) {
                             // Scroll to first selection
                             scrollToRow(modelRows.first() - 1);
                         }
-                    } catch (EditableElementException ex) {
+                    } catch (EditableElementException | SQLException ex) {
                         LOGGER.error(ex.getLocalizedMessage(), ex);
                     } finally {
                             onUpdateEditableSelection.set(false);
@@ -819,11 +819,12 @@ public class TableEditor extends JPanel implements EditorDockable, SourceTable,T
                 tableScrollPane.setRowHeaderView(tableRowHeader);
                 //Apply the selection
                 try {
-                    setRowSelection(tableEditableElement.getSelectionTableRow(), -1);
+                    setRowSelection(tableEditableElement.getRowSet().getRowNumberFromRowPk(tableEditableElement
+                            .getSelection()), -1);
                     if (!table.getSelectionModel().isSelectionEmpty()) {
                         scrollToRow(table.getSelectionModel().getMinSelectionIndex());
                     }
-                } catch (EditableElementException ex) {
+                } catch (EditableElementException |SQLException ex) {
                     LOGGER.error(ex.getLocalizedMessage(), ex);
                 }
                 table.getSelectionModel().addListSelectionListener(
@@ -961,7 +962,7 @@ public class TableEditor extends JPanel implements EditorDockable, SourceTable,T
 
         private void updateEditableSelection() {
                 try {
-                    tableEditableElement.setSelectionTableRow(getTableModelSelection(1));
+                    tableEditableElement.setSelection(ReadTable.getRowPkFromRowNumber(tableEditableElement.getRowSet(), getTableModelSelection(1)));
                     // Update layer selection
                     if (mapContext != null) {
                         TableLocation editorTable = TableLocation.parse(tableEditableElement.getTableReference());
@@ -976,7 +977,7 @@ public class TableEditor extends JPanel implements EditorDockable, SourceTable,T
                             }
                         }
                     }
-                } catch (EditableElementException ex) {
+                } catch (EditableElementException | SQLException ex) {
                     LOGGER.error(ex.getLocalizedMessage(), ex);
                 } finally {
                         onUpdateEditableSelection.set(false);

--- a/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/TableEditor.java
+++ b/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/TableEditor.java
@@ -108,6 +108,7 @@ import org.xnap.commons.i18n.I18nFactory;
 public class TableEditor extends JPanel implements EditorDockable, SourceTable,TableEditListener {
         protected final static I18n I18N = I18nFactory.getI18n(TableEditor.class);
         private static final Logger LOGGER = LoggerFactory.getLogger("gui." + TableEditor.class);
+        private static final int TABLE_SCROLL_PERC = 5;
         
         private static final long serialVersionUID = 1L;
         private TableEditableElement tableEditableElement;
@@ -153,10 +154,10 @@ public class TableEditor extends JPanel implements EditorDockable, SourceTable,T
                 this.tableEditableElement = element;
                 dockingPanelParameters = new DockingPanelParameters();
                 dockingPanelParameters.setTitleIcon(TableEditorIcon.getIcon("table"));
-                dockingPanelParameters.setDefaultDockingLocation(
-                        new DockingLocation(DockingLocation.Location.STACKED_ON, "map_editor"));
+                dockingPanelParameters.setDefaultDockingLocation(new DockingLocation(DockingLocation.Location
+                        .STACKED_ON, "map_editor"));
                 tableScrollPane = new JScrollPane(makeTable());
-                add(tableScrollPane,BorderLayout.CENTER);
+                add(tableScrollPane, BorderLayout.CENTER);
                 updateTitle();
                 // Fetch MapContext
                 if (editorManager != null) {
@@ -843,6 +844,7 @@ public class TableEditor extends JPanel implements EditorDockable, SourceTable,T
                 dockingPanelParameters.setDockActions(getDockActions());
                 initPopupActions();
                 tableModel.fireTableStructureChanged();
+                tableScrollPane.getVerticalScrollBar().setBlockIncrement((int)(table.getHeight() / (TABLE_SCROLL_PERC / 100.)));
         }
         private void initPopupActions() {
                 // TODO Edition

--- a/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/filters/WhereSQLFilterFactory.java
+++ b/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/filters/WhereSQLFilterFactory.java
@@ -32,6 +32,7 @@ import org.h2gis.utilities.TableLocation;
 import org.orbisgis.commons.progress.ProgressMonitor;
 import org.orbisgis.corejdbc.ReadRowSet;
 import org.orbisgis.corejdbc.common.IntegerUnion;
+import org.orbisgis.corejdbc.common.LongUnion;
 import org.orbisgis.sif.components.CustomButton;
 import org.orbisgis.sif.components.filter.DefaultActiveFilter;
 import org.orbisgis.sif.components.filter.FilterFactory;
@@ -57,6 +58,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Set;
+import java.util.SortedSet;
 
 /**
  * Table extended filter using SQL where request
@@ -109,7 +111,7 @@ public class WhereSQLFilterFactory implements FilterFactory<TableSelectionFilter
         return textAndButton;
     }
     private static class SQLFilter implements TableSelectionFilter {
-        private final Set<Integer> filteredRows = new IntegerUnion();
+        private Set<Integer> filteredRows;
         String whereText;
 
         public SQLFilter(String whereText) {
@@ -137,11 +139,13 @@ public class WhereSQLFilterFactory implements FilterFactory<TableSelectionFilter
                                 TableLocation.quoteIdentifier(tablePk),
                                 source.getTableReference(), whereText));
                         LOGGER.info(I18N.tr("Find field value with the following request:\n{0}",request.toString()));
+                        SortedSet<Long> selectionPk = new LongUnion();
                         try(ResultSet rs = st.executeQuery(request.toString())) {
                             while(rs.next()) {
-                                filteredRows.add(rowSet.getRowId(rs.getLong(1)) - 1);
+                                selectionPk.add(rs.getLong(1));
                             }
                         }
+                        filteredRows = rowSet.getRowNumberFromRowPk(selectionPk);
                     }
                 } finally {
                     progress.removePropertyChangeListener(cancelListener);


### PR DESCRIPTION
Greatly speedup table editor, and start time of rending process. (Rendering time is about the same)

Store only row count divide by fetchSize primary keys and use range query on ordered set of primary key. The storage of primary keys is done incrementally while fetching the rows. Random access is speed-up using offset query in order to skip intermediate batch.

This PR change heavily the ReadRowSet and will require extensive debugging.

About #828. 