### PR TITLE
Handle absolute path in Remarks of a linked table

### DIFF
--- a/bundles/core-map/src/main/java/org/orbisgis/coremap/layerModel/Layer.java
+++ b/bundles/core-map/src/main/java/org/orbisgis/coremap/layerModel/Layer.java
@@ -103,15 +103,28 @@ public class Layer extends BeanLayer {
                 try(ResultSet tablesRs = meta.getTables(table.getCatalog(),table.getSchema(),table.getTable(),null)) {
                     if(tablesRs.next()) {
                         String remarks = tablesRs.getString("REMARKS");
-                        if(remarks!= null && remarks.toLowerCase().startsWith("file:")) {
-                            try {
-                                // The table is extracted from a file
-                                URI fileUri =  URI.create(remarks);
-                                if(new File(fileUri).exists()) {
-                                    return fileUri;
+                        if(remarks != null) {
+                            if(remarks.toLowerCase().startsWith("file:")) {
+                                try {
+                                    // The table is extracted from a file
+                                    URI fileUri =  URI.create(remarks);
+                                    if(new File(fileUri).exists()) {
+                                        dataURI = fileUri;
+                                        return fileUri;
+                                    }
+                                } catch (Exception ex) {
+                                    //Ignore, not an URI
                                 }
-                            } catch (Exception ex) {
-                                //Ignore, not an URI
+                            } else {
+                                // Maybe a file
+                                try {
+                                    if (new File(remarks).exists()) {
+                                        dataURI = new File(remarks).toURI();
+                                        return dataURI;
+                                    }
+                                } catch (Exception ex) {
+                                    // Ignore, not a File
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Related to Linux/Windows issue with path resolved in H2GIS.