### PR TITLE
Check for update rights before unlocking modification tool

### DIFF
--- a/bundles/editor-jdbc/src/main/java/org/orbisgis/editorjdbc/EditableSource.java
+++ b/bundles/editor-jdbc/src/main/java/org/orbisgis/editorjdbc/EditableSource.java
@@ -46,6 +46,11 @@ public interface EditableSource extends EditableElement {
     boolean isEditable();
 
     /**
+     * @return Translated explanation of not editable state.
+     */
+    String getNotEditableReason();
+
+    /**
      * Get the data source name
      *
      * @return Table location

--- a/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/ActionEdition.java
+++ b/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/ActionEdition.java
@@ -30,10 +30,14 @@
 package org.orbisgis.tablegui.impl;
 
 
+import org.jooq.SQL;
+import org.orbisgis.corejdbc.MetaData;
 import org.orbisgis.tablegui.api.TableEditableElement;
 import org.orbisgis.tablegui.icons.TableEditorIcon;
 import org.orbisgis.tablegui.impl.ext.TableEditorActions;
 import org.orbisgis.sif.components.actions.ActionTools;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
 
@@ -42,6 +46,8 @@ import javax.swing.*;
 import java.awt.event.ActionEvent;
 import java.beans.EventHandler;
 import java.beans.PropertyChangeListener;
+import java.sql.Connection;
+import java.sql.SQLException;
 
 /**
  * Lock/Unlock table edition action.
@@ -50,6 +56,7 @@ import java.beans.PropertyChangeListener;
 public class ActionEdition extends AbstractAction {
     private final TableEditableElement editable;
     private final I18n i18N = I18nFactory.getI18n(ActionEdition.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ActionEdition.class);
 
     /**
      * Constructor
@@ -78,6 +85,10 @@ public class ActionEdition extends AbstractAction {
     }
     @Override
     public void actionPerformed(ActionEvent actionEvent) {
-        editable.setEditing(!editable.isEditing());
+        if(editable.isEditable()) {
+            editable.setEditing(!editable.isEditing());
+        } else {
+            LOGGER.warn(editable.getNotEditableReason());
+        }
     }
 }

--- a/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/TableEditor.java
+++ b/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/TableEditor.java
@@ -217,14 +217,12 @@ public class TableEditor extends JPanel implements EditorDockable, SourceTable,T
                         .setLogicalGroup(TableEditorActions.LGROUP_READ));
 
                 // Edition is only available if there is a primary key
-                if(tableEditableElement.isEditable()) {
-                        actions.add(new ActionAddColumn(tableEditableElement));
-                        actions.add(new ActionAddRow(tableEditableElement));
-                        actions.add(new ActionRemoveRow(tableEditableElement, this, executorService, undoManager.getLimit()));
-                        actions.add(new ActionUndo(tableEditableElement, undoManager));
-                        actions.add(new ActionRedo(tableEditableElement, undoManager));
-                        actions.add(new ActionEdition(tableEditableElement));
-                }
+                actions.add(new ActionAddColumn(tableEditableElement));
+                actions.add(new ActionAddRow(tableEditableElement));
+                actions.add(new ActionRemoveRow(tableEditableElement, this, executorService, undoManager.getLimit()));
+                actions.add(new ActionUndo(tableEditableElement, undoManager));
+                actions.add(new ActionRedo(tableEditableElement, undoManager));
+                actions.add(new ActionEdition(tableEditableElement));
                 return actions;
         }
 


### PR DESCRIPTION
For many reasons. Users may not be able to update a table. When the user try to unlock the edition mode, some tests are done. If the edition cannot be done then the user is informed of this issue. About #849 