### PR TITLE
Fix constant fields in toolbox

### DIFF
--- a/bundles/wps-client/src/main/java/org/orbisgis/wpsclient/view/ui/dataui/DataFieldUI.java
+++ b/bundles/wps-client/src/main/java/org/orbisgis/wpsclient/view/ui/dataui/DataFieldUI.java
@@ -247,8 +247,20 @@ public class DataFieldUI implements DataUI{
                 ToolTipManager.sharedInstance().setInitialDelay(0);
                 ToolTipManager.sharedInstance().setDismissDelay(2500);
                 String dataFieldStr = dataField.getDataStoreIdentifier().toString();
-                list.setToolTipText("First configure the DataStore : " +
-                        dataFieldStr.substring(dataFieldStr.lastIndexOf(":") + 1));
+                if(dataFieldStr.contains("$")){
+                    String[] split = dataFieldStr.split("\\$");
+                    if(split.length == 2){
+                        dataFieldStr = split[1];
+                    }
+                    else if(split.length == 3){
+                        dataFieldStr = split[1]+"."+split[2];
+                    }
+                    list.setToolTipText("First configure the DataField : " + dataFieldStr);
+                }
+                else {
+                    list.setToolTipText("First configure the DataStore : " +
+                            dataFieldStr.substring(dataFieldStr.lastIndexOf(":") + 1));
+                }
                 ToolTipManager.sharedInstance().mouseMoved(
                         new MouseEvent(list, MouseEvent.MOUSE_MOVED, System.currentTimeMillis(), 0, 0, 0, 0, false));
             }

--- a/bundles/wps-client/src/main/java/org/orbisgis/wpsclient/view/ui/dataui/FieldValueUI.java
+++ b/bundles/wps-client/src/main/java/org/orbisgis/wpsclient/view/ui/dataui/FieldValueUI.java
@@ -194,7 +194,20 @@ public class FieldValueUI implements DataUI{
             ToolTipManager.sharedInstance().setInitialDelay(0);
             ToolTipManager.sharedInstance().setDismissDelay(2500);
             String fieldValueStr = fieldValue.getDataFieldIdentifier().toString();
-            list.setToolTipText("First configure the DataField : " + fieldValueStr.substring(fieldValueStr.lastIndexOf(":")+1));
+            if(fieldValueStr.contains("$")){
+                String[] split = fieldValueStr.split("\\$");
+                if(split.length == 3){
+                    fieldValueStr = split[1]+"."+split[2];
+                }
+                else if(split.length == 4){
+                    fieldValueStr = split[1]+"."+split[2]+"."+split[3];
+                }
+                list.setToolTipText("First configure the DataField : " + fieldValueStr);
+            }
+            else {
+                list.setToolTipText("First configure the DataField : " +
+                        fieldValueStr.substring(fieldValueStr.lastIndexOf(":") + 1));
+            }
             ToolTipManager.sharedInstance().mouseMoved(
                     new MouseEvent(list,MouseEvent.MOUSE_MOVED,System.currentTimeMillis(),0,0,0,0,false));
         }

--- a/bundles/wps-client/src/main/java/org/orbisgis/wpsclient/view/ui/dataui/FieldValueUI.java
+++ b/bundles/wps-client/src/main/java/org/orbisgis/wpsclient/view/ui/dataui/FieldValueUI.java
@@ -145,34 +145,44 @@ public class FieldValueUI implements DataUI{
         HashMap<URI, Object> dataMap = (HashMap<URI, Object>)list.getClientProperty(DATA_MAP_PROPERTY);
         boolean isOptional = (boolean)list.getClientProperty(IS_OPTIONAL_PROPERTY);
         //If the DataField related to the FieldValue has been modified, reload the dataField values
-        if(fieldValue.isDataFieldModified() && dataMap.get(fieldValue.getDataStoreIdentifier()) != null) {
+        if(fieldValue.isDataFieldModified()) {
             fieldValue.setDataFieldModified(false);
-            String tableName;
-            String fieldName;
+            String tableName = null;
+            String fieldName = null;
             if(fieldValue.getDataFieldIdentifier().toString().contains("$")){
                 String[] split = fieldValue.getDataFieldIdentifier().toString().split("\\$");
-                tableName = split[1];
-                fieldName = split[2];
+                if(split.length == 4) {
+                    tableName = split[1]+"."+split[2];
+                    fieldName = split[3];
+                }
+                else if(split.length == 3){
+                    tableName = split[1];
+                    fieldName = split[2];
+                }
+                else{
+                    return;
+                }
             }
-            else{
+            else if (dataMap.get(fieldValue.getDataStoreIdentifier()) != null){
                 tableName = ((URI) dataMap.get(fieldValue.getDataStoreIdentifier())).getSchemeSpecificPart();
                 fieldName = dataMap.get(fieldValue.getDataFieldIdentifier()).toString();
             }
-            DefaultListModel<String> model = (DefaultListModel<String>)list.getModel();
-            model.removeAllElements();
-            List<String> listFields = wpsClient.getWpsService().getFieldValueList(tableName, fieldName);
-            Collections.sort(listFields);
-            for (String field : listFields) {
-                model.addElement(field);
-            }
-            if(listFields.size() < MAX_JLIST_ROW_COUNT){
-                list.setVisibleRowCount(listFields.size());
-            }
-            else{
-                list.setVisibleRowCount(MAX_JLIST_ROW_COUNT);
-            }
-            if(!isOptional && list.getModel().getSize() > 0){
-                list.setSelectedIndex(0);
+            if(tableName != null && fieldName != null) {
+                DefaultListModel<String> model = (DefaultListModel<String>) list.getModel();
+                model.removeAllElements();
+                List<String> listFields = wpsClient.getWpsService().getFieldValueList(tableName, fieldName);
+                Collections.sort(listFields);
+                for (String field : listFields) {
+                    model.addElement(field);
+                }
+                if (listFields.size() < MAX_JLIST_ROW_COUNT) {
+                    list.setVisibleRowCount(listFields.size());
+                } else {
+                    list.setVisibleRowCount(MAX_JLIST_ROW_COUNT);
+                }
+                if (!isOptional && list.getModel().getSize() > 0) {
+                    list.setSelectedIndex(0);
+                }
             }
         }
 

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/LocalWpsServiceImplementation.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/LocalWpsServiceImplementation.java
@@ -494,6 +494,9 @@ public class LocalWpsServiceImplementation implements LocalWpsService {
         try(Connection connection = dataManager.getDataSource().getConnection()) {
             tableName = TableLocation.parse(tableName, isH2).getTable();
             List<String> fieldNames = JDBCUtilities.getFieldNames(connection.getMetaData(), tableName);
+            if(fieldNames.isEmpty()){
+                return fieldValues;
+            }
             for(String field : fieldNames){
                 if(field.equalsIgnoreCase(fieldName)){
                     fieldName = field;


### PR DESCRIPTION
Fixes the issue #978 and #979 about the fixed DataField and fixed DataStore.
Now the DataSource of the DataField can be fixed : `dataStore = "\$schema\$table\$"`.
Now the DataField of the FieldValue can be fixed : `dataField = "\$schema\$table\$filed\$"`.