### PR TITLE
Add/Remove row in wps

### DIFF
--- a/bundles/table-editor/pom.xml
+++ b/bundles/table-editor/pom.xml
@@ -126,5 +126,10 @@
             <artifactId>spatial-utilities</artifactId>
             <version>${h2-gis-version}</version>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wps-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/bundles/table-editor/pom.xml
+++ b/bundles/table-editor/pom.xml
@@ -131,10 +131,5 @@
             <artifactId>wps-service</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.orbisgis</groupId>
-            <artifactId>wps-service</artifactId>
-            <version>5.1.0-SNAPSHOT</version>
-        </dependency>
     </dependencies>
 </project>

--- a/bundles/table-editor/pom.xml
+++ b/bundles/table-editor/pom.xml
@@ -131,5 +131,10 @@
             <artifactId>wps-service</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.orbisgis</groupId>
+            <artifactId>wps-service</artifactId>
+            <version>5.1.0-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 </project>

--- a/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/ActionAddRow.java
+++ b/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/ActionAddRow.java
@@ -61,8 +61,11 @@ import java.util.Map;
  * @author Nicolas Fortin
  */
 public class ActionAddRow extends AbstractAction {
+    /** Title of the wps process to use. */
     private static final String PROCESS_TITLE = "InsertInto";
+    /** Name of the process input containing the table name. */
     private static final String INPUT_TABLE = "Table";
+    /** Name of the process input containing the values to add. */
     private static final String INPUT_VALUES = "Values";
     private final TableEditableElement editable;
     private static final I18n I18N = I18nFactory.getI18n(ActionAddRow.class);
@@ -100,6 +103,7 @@ public class ActionAddRow extends AbstractAction {
                 AskValidRow rowInput = new AskValidRow(I18N.tr("New row"), source, editable.getTableReference());
                 if(UIFactory.showDialog(rowInput)) {
                     if(wpsService != null){
+                        //Firs try to retrieve the process corresponding to the process title.
                         Process p = null;
                         for(ProcessIdentifier pi : wpsService.getCapabilities()){
                             if(pi.getProcess().getTitle().equals(PROCESS_TITLE)){
@@ -108,20 +112,22 @@ public class ActionAddRow extends AbstractAction {
                             }
                         }
                         if(p != null){
-                            //Get the values formatted string
+                            //Get the string containing the values to add separated by a coma.
                             String values = "";
-                            boolean flag = false;
+                            boolean isEmptyString = true;
                             Object[] newRow = rowInput.getRow();
                             for(Object o : newRow){
-                                if(flag){
+                                if(!isEmptyString){
                                     values += ",";
                                 }
+                                //If the value is null, put an empty string,
+                                // the process will convert it into a null value.
                                 if(o != null){
                                     values += o.toString();
                                 }
-                                flag = true;
+                                isEmptyString = false;
                             }
-                            //Build the dataMap
+                            //Build the dataMap containing the process input
                             Map<URI, Object> dataMap = new HashMap<>();
                             for (Input input : p.getInput()) {
                                 if (input.getTitle().equals(INPUT_TABLE)) {
@@ -142,6 +148,9 @@ public class ActionAddRow extends AbstractAction {
                                     null,
                                     null,
                                     TableModelEvent.UPDATE));
+                        }
+                        else{
+                            LOGGER.error(I18N.tr("Unable to get the process '{0}' from the WpsService.", PROCESS_TITLE));
                         }
                     }
                 }

--- a/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/ActionRemoveRow.java
+++ b/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/ActionRemoveRow.java
@@ -29,12 +29,16 @@
 
 package org.orbisgis.tablegui.impl;
 
-import org.orbisgis.editorjdbc.jobs.DeleteSelectedRows;
+import org.h2gis.utilities.JDBCUtilities;
 import org.orbisgis.sif.components.actions.ActionTools;
-import org.orbisgis.sif.edition.EditableElementException;
 import org.orbisgis.tablegui.api.TableEditableElement;
 import org.orbisgis.tablegui.icons.TableEditorIcon;
 import org.orbisgis.tablegui.impl.ext.TableEditorActions;
+import org.orbisgis.wpsservice.controller.execution.ProcessExecutionListener;
+import org.orbisgis.wpsservice.model.Input;
+import org.orbisgis.wpsservice.model.Process;
+import org.orbisgis.wpsservice.WpsService;
+import org.orbisgis.wpsservice.controller.process.ProcessIdentifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
@@ -46,8 +50,11 @@ import java.awt.event.ActionEvent;
 import java.beans.EventHandler;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.net.URI;
+import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.concurrent.ExecutorService;
@@ -57,64 +64,113 @@ import java.util.concurrent.ExecutorService;
  * @author Nicolas Fortin
  */
 public class ActionRemoveRow extends AbstractAction {
-        private final TableEditableElement editable;
-        private static final I18n I18N = I18nFactory.getI18n(ActionRemoveRow.class);
-        private Component parentComponent;
-        private ExecutorService executorService;
-        private final int limitUndoableDelete;
-        private static final Logger LOGGER = LoggerFactory.getLogger(ActionRemoveRow.class);
+    private static final String PROCESS_TITLE = "RemoveRow";
+    private static final String INPUT_TABLE = "Table";
+    private static final String INPUT_PK_FIELD = "PKField";
+    private static final String INPUT_PK_ARRAY = "PKArray";
+    private final TableEditableElement editable;
+    private static final I18n I18N = I18nFactory.getI18n(ActionRemoveRow.class);
+    private Component parentComponent;
+    private ExecutorService executorService;
+    private final int limitUndoableDelete;
+    private static final Logger LOGGER = LoggerFactory.getLogger(ActionRemoveRow.class);
+    private WpsService wpsService;
 
-        /**
-         * Constructor
-         * @param editable Table editable instance
-         */
-        public ActionRemoveRow(TableEditableElement editable, Component parentComponent,ExecutorService executorService, int limitUndoableDelete) {
-                super(I18N.tr("Delete selected rows"), TableEditorIcon.getIcon("delete_row"));
-                this.parentComponent = parentComponent;
-                this.executorService = executorService;
-                this.limitUndoableDelete = limitUndoableDelete;
-                putValue(ActionTools.LOGICAL_GROUP, TableEditorActions.LGROUP_MODIFICATION_GROUP);
-                putValue(ActionTools.MENU_ID,TableEditorActions.A_REMOVE_ROW);
-                this.editable = editable;
-                updateEnabledState();
-                editable.addPropertyChangeListener(EventHandler.create(PropertyChangeListener.class, this, "onEditableUpdate",""));
-        }
+    /**
+     * Constructor
+     * @param editable Table editable instance
+     */
+    public ActionRemoveRow(TableEditableElement editable, Component parentComponent,ExecutorService executorService, int limitUndoableDelete, WpsService wpsService) {
+        super(I18N.tr("Delete selected rows"), TableEditorIcon.getIcon("delete_row"));
+        this.parentComponent = parentComponent;
+        this.executorService = executorService;
+        this.limitUndoableDelete = limitUndoableDelete;
+        putValue(ActionTools.LOGICAL_GROUP, TableEditorActions.LGROUP_MODIFICATION_GROUP);
+        putValue(ActionTools.MENU_ID,TableEditorActions.A_REMOVE_ROW);
+        this.editable = editable;
+        updateEnabledState();
+        editable.addPropertyChangeListener(EventHandler.create(PropertyChangeListener.class, this, "onEditableUpdate",""));
+        this.wpsService = wpsService;
+    }
 
-        /**
-         * Enable this action only if edition is enabled
-         */
-        public void onEditableUpdate(PropertyChangeEvent evt) {
-                if(TableEditableElement.PROP_SELECTION.equals(evt.getPropertyName())
-                        || TableEditableElement.PROP_EDITING.equals(evt.getPropertyName())) {
-                        updateEnabledState();
-                }
+    /**
+     * Enable this action only if edition is enabled
+     */
+    public void onEditableUpdate(PropertyChangeEvent evt) {
+        if(TableEditableElement.PROP_SELECTION.equals(evt.getPropertyName())
+            || TableEditableElement.PROP_EDITING.equals(evt.getPropertyName())) {
+            updateEnabledState();
         }
-        private void updateEnabledState() {
-                setEnabled(editable.isEditing() && !editable.getSelection().isEmpty());
-        }
-        @Override
-        public void actionPerformed(ActionEvent actionEvent) {
-                if(editable.isEditing()) {
-                        Set<Long> selectedRows = editable.getSelection();
-                        int response = JOptionPane.showConfirmDialog(parentComponent,
-                                I18N.tr("Are you sure to remove the {0} selected rows ?", selectedRows.size()),
-                                I18N.tr("Delete selected rows"),
-                                JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);
-                        if(response == JOptionPane.YES_OPTION) {
-                                SortedSet<Long> pkToDelete = editable.getSelection();
-                                if(pkToDelete.size() > limitUndoableDelete) {
-                                    // Launch process without undoing capabilities
-                                    executorService.execute(new DeleteSelectedRows(editable.getSelection(), editable.getTableReference(), editable.getDataManager().getDataSource()));
-                                } else {
-                                    // Launch process with undoing capabilities
-                                    try {
-                                        DeleteSelectedRows.deleteUsingRowSet(editable.getRowSet(), pkToDelete);
-                                    } catch (EditableElementException | InterruptedException | SQLException ex) {
-                                        LOGGER.error(ex.getLocalizedMessage(), ex);
-                                    }
-                                }
+    }
+    private void updateEnabledState() {
+            setEnabled(editable.isEditing() && !editable.getSelection().isEmpty());
+    }
+    @Override
+    public void actionPerformed(ActionEvent actionEvent) {
+        if(editable.isEditing()) {
+            Set<Long> selectedRows = editable.getSelection();
+            int response = JOptionPane.showConfirmDialog(parentComponent,
+                I18N.tr("Are you sure to remove the {0} selected rows ?", selectedRows.size()),
+                I18N.tr("Delete selected rows"),
+                JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);
+            if(response == JOptionPane.YES_OPTION) {
+                if(wpsService != null){
+                    Process p = null;
+                    for(ProcessIdentifier pi : wpsService.getCapabilities()){
+                        if(pi.getProcess().getTitle().equals(PROCESS_TITLE)){
+                            p = pi.getProcess();
+                            break;
                         }
-                }
-        }
+                    }
+                    if(p != null){
+                        try(Connection connection = editable.getDataManager().getDataSource().getConnection()) {
+                            //Gets the pk column name
+                            int columnId = JDBCUtilities.getIntegerPrimaryKey(connection, editable.getTableReference());
+                            String pkColumnName = JDBCUtilities.getFieldName(connection.getMetaData(), editable.getTableReference(), columnId);
+                            //Gets the pk list as a String[]
+                            String[] pkList = new String[editable.getSelection().size()];
+                            SortedSet<Long> selection = editable.getSelection();
+                            int i = 0;
+                            for (Long l : selection) {
+                                pkList[i] = l.toString();
+                                i++;
+                            }
+                            //Build the dataMap
+                            Map<URI, Object> dataMap = new HashMap<>();
+                            for (Input input : p.getInput()) {
+                                if (input.getTitle().equals(INPUT_TABLE)) {
+                                    dataMap.put(input.getIdentifier(), URI.create("geocatalog:" + editable.getTableReference() + "#" + editable.getTableReference()));
+                                }
+                                if (input.getTitle().equals(INPUT_PK_ARRAY)) {
+                                    dataMap.put(input.getIdentifier(), pkList);
+                                }
+                                if (input.getTitle().equals(INPUT_PK_FIELD)) {
+                                    dataMap.put(input.getIdentifier(), pkColumnName);
+                                }
+                            }
+                            //Run the service
+                            wpsService.execute(p, dataMap, new ProcessExecutionListener() {
+                                @Override
+                                public void setStartTime(long time) {
 
+                                }
+
+                                @Override
+                                public void appendLog(LogType logType, String message) {
+                                    System.out.println(message);
+                                }
+
+                                @Override
+                                public void setProcessState(ProcessState processState) {
+
+                                }
+                            });
+                        } catch (SQLException e) {
+                            LOGGER.error("Unable to get the connection to remove rows.\n"+e.getMessage());
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/ActionRemoveRow.java
+++ b/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/ActionRemoveRow.java
@@ -35,7 +35,6 @@ import org.orbisgis.sif.components.actions.ActionTools;
 import org.orbisgis.tablegui.api.TableEditableElement;
 import org.orbisgis.tablegui.icons.TableEditorIcon;
 import org.orbisgis.tablegui.impl.ext.TableEditorActions;
-import org.orbisgis.wpsservice.controller.execution.ProcessExecutionListener;
 import org.orbisgis.wpsservice.model.DataStore;
 import org.orbisgis.wpsservice.model.Input;
 import org.orbisgis.wpsservice.model.Process;
@@ -48,7 +47,6 @@ import org.xnap.commons.i18n.I18nFactory;
 
 import javax.swing.*;
 import javax.swing.event.TableModelEvent;
-import java.awt.Component;
 import java.awt.event.ActionEvent;
 import java.beans.EventHandler;
 import java.beans.PropertyChangeEvent;
@@ -60,7 +58,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
-import java.util.concurrent.ExecutorService;
 
 /**
  * Remove selected rows in the DataSource.

--- a/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/ActionRemoveRow.java
+++ b/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/ActionRemoveRow.java
@@ -65,9 +65,13 @@ import java.util.SortedSet;
  * @author Sylvain PALOMINOS
  */
 public class ActionRemoveRow extends AbstractAction {
+    /** Title of the wps process to use. */
     private static final String PROCESS_TITLE = "RemoveRow";
+    /** Name of the process input containing the table name. */
     private static final String INPUT_TABLE = "Table";
+    /** Name of the process input containing the primary key field name. */
     private static final String INPUT_PK_FIELD = "PKField";
+    /** Name of the process input containing the primary key array. */
     private static final String INPUT_PK_ARRAY = "PKArray";
     private final TableEditableElement editable;
     private static final I18n I18N = I18nFactory.getI18n(ActionRemoveRow.class);
@@ -159,6 +163,9 @@ public class ActionRemoveRow extends AbstractAction {
                         } catch (SQLException e) {
                             LOGGER.error(I18N.tr("Unable to get the connection to remove rows.\n")+e.getMessage());
                         }
+                    }
+                    else{
+                        LOGGER.error(I18N.tr("Unable to get the process '{0}' from the WpsService.", PROCESS_TITLE));
                     }
                 }
             }

--- a/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/TableEditor.java
+++ b/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/TableEditor.java
@@ -102,6 +102,9 @@ import org.orbisgis.tablegui.impl.filters.WhereSQLFilterFactory;
 import org.orbisgis.tablegui.impl.jobs.ComputeFieldStatistics;
 import org.orbisgis.tablegui.impl.jobs.OptimalWidthJob;
 import org.orbisgis.tablegui.impl.jobs.SearchJob;
+import org.orbisgis.wpsservice.LocalWpsService;
+import org.orbisgis.wpsservice.WpsService;
+import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
@@ -145,12 +148,13 @@ public class TableEditor extends JPanel implements EditorDockable, SourceTable,T
         private int currentSelectionNavigation = 0;
         private EditorManager editorManager;
         private ExecutorService executorService;
+        private WpsService wpsService;
 
         /**
          * Constructor
          * @param element Source to read and edit
          */
-        public TableEditor(TableEditableElement element, DataManager dataManager, EditorManager editorManager, ExecutorService executorService) {
+        public TableEditor(TableEditableElement element, DataManager dataManager, EditorManager editorManager, ExecutorService executorService, WpsService wpsService) {
                 super(new BorderLayout());
                 this.editorManager = editorManager;
                 this.executorService = executorService;
@@ -175,6 +179,7 @@ public class TableEditor extends JPanel implements EditorDockable, SourceTable,T
                         registerMapContext(mapContext);
                     }
                 }
+            this.wpsService = wpsService;
         }
 
         public void onMenuRefresh() {
@@ -219,7 +224,7 @@ public class TableEditor extends JPanel implements EditorDockable, SourceTable,T
                 // Edition is only available if there is a primary key
                 //TODO : actions.add(new ActionAddColumn(tableEditableElement));
                 actions.add(new ActionAddRow(tableEditableElement));
-                actions.add(new ActionRemoveRow(tableEditableElement, this, executorService, undoManager.getLimit()));
+                actions.add(new ActionRemoveRow(tableEditableElement, this, executorService, undoManager.getLimit(), wpsService));
                 actions.add(new ActionUndo(tableEditableElement, undoManager));
                 actions.add(new ActionRedo(tableEditableElement, undoManager));
                 actions.add(new ActionEdition(tableEditableElement));
@@ -1319,5 +1324,4 @@ public class TableEditor extends JPanel implements EditorDockable, SourceTable,T
             return true;
         }
     }
-
 }

--- a/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/TableEditor.java
+++ b/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/TableEditor.java
@@ -223,7 +223,7 @@ public class TableEditor extends JPanel implements EditorDockable, SourceTable,T
 
                 // Edition is only available if there is a primary key
                 //TODO : actions.add(new ActionAddColumn(tableEditableElement));
-                actions.add(new ActionAddRow(tableEditableElement));
+                actions.add(new ActionAddRow(tableEditableElement, this, wpsService));
                 actions.add(new ActionRemoveRow(tableEditableElement, this, wpsService));
                 actions.add(new ActionUndo(tableEditableElement, undoManager));
                 actions.add(new ActionRedo(tableEditableElement, undoManager));

--- a/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/TableEditor.java
+++ b/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/TableEditor.java
@@ -224,7 +224,7 @@ public class TableEditor extends JPanel implements EditorDockable, SourceTable,T
                 // Edition is only available if there is a primary key
                 //TODO : actions.add(new ActionAddColumn(tableEditableElement));
                 actions.add(new ActionAddRow(tableEditableElement));
-                actions.add(new ActionRemoveRow(tableEditableElement, this, executorService, undoManager.getLimit(), wpsService));
+                actions.add(new ActionRemoveRow(tableEditableElement, this, wpsService));
                 actions.add(new ActionUndo(tableEditableElement, undoManager));
                 actions.add(new ActionRedo(tableEditableElement, undoManager));
                 actions.add(new ActionEdition(tableEditableElement));

--- a/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/TableEditor.java
+++ b/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/TableEditor.java
@@ -222,9 +222,11 @@ public class TableEditor extends JPanel implements EditorDockable, SourceTable,T
                         .setLogicalGroup(TableEditorActions.LGROUP_READ));
 
                 // Edition is only available if there is a primary key
-                //TODO : actions.add(new ActionAddColumn(tableEditableElement));
-                actions.add(new ActionAddRow(tableEditableElement, this, wpsService));
-                actions.add(new ActionRemoveRow(tableEditableElement, this, wpsService));
+                if(wpsService != null) {
+                        //TODO : actions.add(new ActionAddColumn(tableEditableElement));
+                        actions.add(new ActionAddRow(tableEditableElement, this, wpsService));
+                        actions.add(new ActionRemoveRow(tableEditableElement, this, wpsService));
+                }
                 actions.add(new ActionUndo(tableEditableElement, undoManager));
                 actions.add(new ActionRedo(tableEditableElement, undoManager));
                 actions.add(new ActionEdition(tableEditableElement));

--- a/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/TableEditorFactory.java
+++ b/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/TableEditorFactory.java
@@ -40,6 +40,8 @@ import org.orbisgis.wpsservice.LocalWpsService;
 import org.orbisgis.wpsservice.WpsService;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnap.commons.i18n.I18n;
@@ -58,7 +60,7 @@ public class TableEditorFactory implements EditorFactory {
         private DataManager dataManager;
         private EditorManager editorManager;
         private ExecutorService executorService;
-        private WpsService wpsService;
+        private WpsService wpsService = null;
 
         @Override
         public DockingPanelLayout makeEditableLayout(EditableElement editable) {
@@ -96,7 +98,7 @@ public class TableEditorFactory implements EditorFactory {
             this.editorManager = null;
         }
 
-    @Reference
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL)
     public void setLocalWpsService(LocalWpsService wpsService) {
         this.wpsService = wpsService;
     }

--- a/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/TableEditorFactory.java
+++ b/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/TableEditorFactory.java
@@ -36,6 +36,8 @@ import org.orbisgis.sif.edition.EditorDockable;
 import org.orbisgis.sif.edition.EditorManager;
 import org.orbisgis.sif.edition.EditorFactory;
 import org.orbisgis.tablegui.api.TableEditableElement;
+import org.orbisgis.wpsservice.LocalWpsService;
+import org.orbisgis.wpsservice.WpsService;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
@@ -56,6 +58,7 @@ public class TableEditorFactory implements EditorFactory {
         private DataManager dataManager;
         private EditorManager editorManager;
         private ExecutorService executorService;
+        private WpsService wpsService;
 
         @Override
         public DockingPanelLayout makeEditableLayout(EditableElement editable) {
@@ -92,6 +95,15 @@ public class TableEditorFactory implements EditorFactory {
         public void unsetEditorManager(EditorManager editorManager) {
             this.editorManager = null;
         }
+
+    @Reference
+    public void setLocalWpsService(LocalWpsService wpsService) {
+        this.wpsService = wpsService;
+    }
+
+    public void unsetLocalWpsService(LocalWpsService wpsService) {
+        this.wpsService = null;
+    }
 
         /**
          * @param dataManager JDBC DataManager factory
@@ -131,7 +143,7 @@ public class TableEditorFactory implements EditorFactory {
         public EditorDockable create(DockingPanelLayout layout) {
                 TableEditableElement editableTable = ((TablePanelLayout)layout).getTableEditableElement();
                 //Check the DataSource state
-                return new TableEditor(editableTable, dataManager, editorManager, executorService);
+                return new TableEditor(editableTable, dataManager, editorManager, executorService, wpsService);
         }
 
         @Override

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/LocalWpsServiceImplementation.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/LocalWpsServiceImplementation.java
@@ -311,11 +311,11 @@ public class LocalWpsServiceImplementation implements LocalWpsService {
         }
         catch (Exception e) {
             if(pel != null) {
-                pel.setProcessState(ProcessExecutionListener.ProcessState.ERROR);
                 //Print in the log the process execution error
                 pel.appendLog(ProcessExecutionListener.LogType.ERROR, e.getMessage());
                 //Post-process the data
                 pel.appendLog(ProcessExecutionListener.LogType.INFO, "Post-processing");
+                pel.setProcessState(ProcessExecutionListener.ProcessState.ERROR);
             }
             else{
                 LoggerFactory.getLogger(LocalWpsServiceImplementation.class).error("Error on execution the WPS " +

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/LocalWpsServiceImplementation.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/LocalWpsServiceImplementation.java
@@ -253,16 +253,21 @@ public class LocalWpsServiceImplementation implements LocalWpsService {
     }
 
     public void execute(Process process, Map<URI, Object> dataMap, ProcessExecutionListener pel){
-
-        pel.setStartTime(System.currentTimeMillis());
+        if(pel != null) {
+            pel.setStartTime(System.currentTimeMillis());
+        }
         Map<URI, Object> stash = new HashMap<>();
         //Catch all the Exception that can be thrown during the script execution.
         try {
             //Print in the log the process execution start
-            pel.appendLog(ProcessExecutionListener.LogType.INFO, "Start the process");
+            if(pel != null) {
+                pel.appendLog(ProcessExecutionListener.LogType.INFO, "Start the process");
+            }
 
             //Pre-process the data
-            pel.appendLog(ProcessExecutionListener.LogType.INFO, "Pre-processing");
+            if(pel != null) {
+                pel.appendLog(ProcessExecutionListener.LogType.INFO, "Pre-processing");
+            }
             for(DescriptionType inputOrOutput : process.getOutput()){
                 stash.putAll(dataProcessingManager.preProcessData(inputOrOutput, dataMap, pel));
             }
@@ -271,11 +276,15 @@ public class LocalWpsServiceImplementation implements LocalWpsService {
             }
 
             //Execute the process and retrieve the groovy object.
-            pel.appendLog(ProcessExecutionListener.LogType.INFO, "Execute the script");
+            if(pel != null) {
+                pel.appendLog(ProcessExecutionListener.LogType.INFO, "Execute the script");
+            }
             processManager.executeProcess(process, dataMap);
 
             //Post-process the data
-            pel.appendLog(ProcessExecutionListener.LogType.INFO, "Post-processing");
+            if(pel != null) {
+                pel.appendLog(ProcessExecutionListener.LogType.INFO, "Post-processing");
+            }
             for(DescriptionType inputOrOutput : process.getOutput()){
                 dataProcessingManager.postProcessData(inputOrOutput, dataMap, stash, pel);
             }
@@ -284,15 +293,23 @@ public class LocalWpsServiceImplementation implements LocalWpsService {
             }
 
             //Print in the log the process execution end
-            pel.appendLog(ProcessExecutionListener.LogType.INFO, "End of the process");
-            pel.setProcessState(ProcessExecutionListener.ProcessState.COMPLETED);
+            if(pel != null) {
+                pel.appendLog(ProcessExecutionListener.LogType.INFO, "End of the process");
+                pel.setProcessState(ProcessExecutionListener.ProcessState.COMPLETED);
+            }
         }
         catch (Exception e) {
-            pel.setProcessState(ProcessExecutionListener.ProcessState.ERROR);
-            //Print in the log the process execution error
-            pel.appendLog(ProcessExecutionListener.LogType.ERROR, e.getMessage());
-            //Post-process the data
-            pel.appendLog(ProcessExecutionListener.LogType.INFO, "Post-processing");
+            if(pel != null) {
+                pel.setProcessState(ProcessExecutionListener.ProcessState.ERROR);
+                //Print in the log the process execution error
+                pel.appendLog(ProcessExecutionListener.LogType.ERROR, e.getMessage());
+                //Post-process the data
+                pel.appendLog(ProcessExecutionListener.LogType.INFO, "Post-processing");
+            }
+            else{
+                LoggerFactory.getLogger(LocalWpsServiceImplementation.class).error("Error on execution the WPS " +
+                        "process '"+process.getTitle()+"'.\n"+e.getMessage());
+            }
             for(DescriptionType inputOrOutput : process.getInput()){
                 dataProcessingManager.postProcessData(inputOrOutput, dataMap, stash, pel);
             }

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/WpsService.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/WpsService.java
@@ -17,5 +17,13 @@ public interface WpsService {
 
     Process describeProcess(URI uri);
 
+    /**
+     * Execute the given process with the given dataMap.
+     * The process results will be put into the dataMap.
+     * The process execution will be log in the processExecutionListener (which ca be null).
+     * @param process Process to execute.
+     * @param dataMap DataMap containing all the data (input and output)
+     * @param pel Process executionListener used to log the process execution (can be null).
+     */
     void execute(Process process, Map<URI, Object> dataMap, ProcessExecutionListener pel);
 }

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/execution/DataProcessing.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/execution/DataProcessing.java
@@ -36,8 +36,24 @@ public interface DataProcessing {
 
     void setLocalWpsService(LocalWpsService wpsService);
     Class<? extends DataDescription> getDataClass();
+
+    /**
+     * Preprocess the input/output to adapt it to the process (i.e. convert a File into a table name).
+     * @param inputOrOutput The DescriptionType representing the input or output.
+     * @param dataMap DataMap containing the input or output values.
+     * @param pel ProcessExecutionListener to log the preprocessing (can be null).
+     * @return Return a stash map containing information for post processing.
+     */
     Map<URI, Object> preProcessData(DescriptionType inputOrOutput, Map<URI, Object> dataMap,
                                     ProcessExecutionListener pel);
+
+    /**
+     * Postprocess the input/output to adapt it to the process (i.e. convert a File into a table name).
+     * @param inputOrOutput The DescriptionType representing the input or output.
+     * @param dataMap DataMap containing the input or output values.
+     * @param stash DataMap containing the information coming from the preprocessing.
+     * @param pel ProcessExecutionListener to log the postprocessing (can be null).
+     */
     void postProcessData(DescriptionType inputOrOutput, Map<URI, Object> dataMap, Map<URI, Object> stash,
                          ProcessExecutionListener pel);
 }

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/execution/DataStoreProcessing.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/execution/DataStoreProcessing.java
@@ -22,6 +22,8 @@ package org.orbisgis.wpsservice.controller.execution;
 import org.orbisgis.wpsservice.LocalWpsService;
 import org.orbisgis.wpsservice.controller.execution.ProcessExecutionListener.LogType;
 import org.orbisgis.wpsservice.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.util.HashMap;
@@ -31,6 +33,9 @@ import java.util.Map;
  * @author Sylvain PALOMINOS
  */
 public class DataStoreProcessing implements DataProcessing {
+
+    /**Logger */
+    private Logger LOGGER = LoggerFactory.getLogger(DataStoreProcessing.class);
 
     private LocalWpsService wpsService;
 
@@ -113,14 +118,18 @@ public class DataStoreProcessing implements DataProcessing {
                 boolean keep = path.endsWith("$");
                 path = path.replace("$", "");
                 wpsService.saveURI(URI.create(dataStoreURI.getScheme()+":"+path), dataMap.get(uri).toString());
-                pel.appendLog(LogType.INFO, "Table '"+dataMap.get(uri).toString()+"' successfully exported into '"+
-                        path+"'.");
+                if(pel != null) {
+                    pel.appendLog(LogType.INFO, "Table '" + dataMap.get(uri).toString() + "' successfully exported into '" +
+                            path + "'.");
+                }
                 if(!keep){
                     wpsService.removeTempTable(dataMap.get(uri).toString());
                 }
             }
             else if(dataStoreURI.getScheme().equals("geocatalog")){
-                pel.appendLog(LogType.INFO, "Table '"+dataMap.get(uri).toString()+"' successfully created.");
+                if(pel != null) {
+                    pel.appendLog(LogType.INFO, "Table '" + dataMap.get(uri).toString() + "' successfully created.");
+                }
             }
         }
     }

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/execution/GeometryProcessing.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/execution/GeometryProcessing.java
@@ -6,6 +6,8 @@ import com.vividsolutions.jts.io.WKTReader;
 import com.vividsolutions.jts.io.WKTWriter;
 import org.orbisgis.wpsservice.LocalWpsService;
 import org.orbisgis.wpsservice.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.util.HashMap;
@@ -15,6 +17,9 @@ import java.util.Map;
  * @author Sylvain PALOMINOS
  */
 public class GeometryProcessing implements DataProcessing {
+
+    /**Logger */
+    private Logger LOGGER = LoggerFactory.getLogger(GeometryProcessing.class);
 
     private LocalWpsService wpsService;
 
@@ -44,8 +49,13 @@ public class GeometryProcessing implements DataProcessing {
                 try {
                     geometry = new WKTReader().read(str);
                 } catch (ParseException e) {
-                    pel.appendLog(ProcessExecutionListener.LogType.ERROR,"Unable to parse the string '" + str +
-                            "' into Geometry.");
+                    if(pel != null) {
+                        pel.appendLog(ProcessExecutionListener.LogType.ERROR, "Unable to parse the string '" + str +
+                                "' into Geometry.");
+                    }
+                    else{
+                        LOGGER.error("Unable to parse the string '" + str + "' into Geometry.");
+                    }
                     dataMap.put(inputOrOutput.getIdentifier(), null);
                     return null;
                 }
@@ -58,8 +68,14 @@ public class GeometryProcessing implements DataProcessing {
                     }
                 }
                 if(!flag){
-                    pel.appendLog(ProcessExecutionListener.LogType.ERROR,"The geometry '"+input.getTitle()+
-                            "' type is not accepted ('"+geometry.getGeometryType()+"' not allowed).");
+                    if(pel != null) {
+                        pel.appendLog(ProcessExecutionListener.LogType.ERROR, "The geometry '" + input.getTitle() +
+                                "' type is not accepted ('" + geometry.getGeometryType() + "' not allowed).");
+                    }
+                    else{
+                        LOGGER.error("The geometry '" + input.getTitle() + "' type is not accepted ('" +
+                                geometry.getGeometryType() + "' not allowed).");
+                    }
                     dataMap.put(inputOrOutput.getIdentifier(), null);
                     return null;
                 }
@@ -71,16 +87,29 @@ public class GeometryProcessing implements DataProcessing {
                     }
                 }
                 if(!flag){
-                    pel.appendLog(ProcessExecutionListener.LogType.ERROR,"The geometry '"+input.getTitle()+
-                            "' type is not accepted ('"+geometry.getGeometryType()+"' not allowed).");
+                    if(pel != null) {
+                        pel.appendLog(ProcessExecutionListener.LogType.ERROR, "The geometry '" + input.getTitle() +
+                                "' type is not accepted ('" + geometry.getGeometryType() + "' not allowed).");
+                    }
+                    else{
+                        LOGGER.error("The geometry '" + input.getTitle() + "' type is not accepted ('" +
+                                geometry.getGeometryType() + "' not allowed).");
+                    }
                     dataMap.put(inputOrOutput.getIdentifier(), null);
                     return null;
                 }
                 //Check the geometry dimension
                 if((geometryData.getDimension() == 2 && !Double.isNaN(geometry.getCoordinate().z)) ||
                         (geometryData.getDimension() == 3 && Double.isNaN(geometry.getCoordinate().z))){
-                    pel.appendLog(ProcessExecutionListener.LogType.ERROR,"The geometry '"+input.getTitle()+
-                            "' has not a wrong dimension (should be '"+geometryData.getDimension()+"').");
+                    if(pel != null) {
+                        pel.appendLog(ProcessExecutionListener.LogType.ERROR, "The geometry '" + input.getTitle() +
+                                "' has not a wrong dimension (should be '" + geometryData.getDimension() + "').");
+                    }
+                    else{
+
+                        LOGGER.error("The geometry '" + input.getTitle() + "' has not a wrong dimension (should be '" +
+                                geometryData.getDimension() + "').");
+                    }
                     dataMap.put(inputOrOutput.getIdentifier(), null);
                     return null;
                 }
@@ -118,8 +147,14 @@ public class GeometryProcessing implements DataProcessing {
                         }
                     }
                     if (!flag) {
-                        pel.appendLog(ProcessExecutionListener.LogType.ERROR,"The geometry '" + output.getTitle() +
-                                "' type is not accepted ('" + geometry.getGeometryType() + "' not allowed).");
+                        if(pel != null) {
+                            pel.appendLog(ProcessExecutionListener.LogType.ERROR, "The geometry '" + output.getTitle() +
+                                    "' type is not accepted ('" + geometry.getGeometryType() + "' not allowed).");
+                        }
+                        else{
+                            LOGGER.error("The geometry '" + output.getTitle() + "' type is not accepted ('" +
+                                    geometry.getGeometryType() + "' not allowed).");
+                        }
                         dataMap.put(inputOrOutput.getIdentifier(), null);
                         return;
                     }
@@ -131,23 +166,36 @@ public class GeometryProcessing implements DataProcessing {
                         }
                     }
                     if (!flag) {
-                        pel.appendLog(ProcessExecutionListener.LogType.ERROR,"The geometry '" + output.getTitle() +
-                                "' type is not accepted ('" + geometry.getGeometryType() + "' not allowed).");
+                        if(pel != null) {
+                            pel.appendLog(ProcessExecutionListener.LogType.ERROR, "The geometry '" + output.getTitle() +
+                                    "' type is not accepted ('" + geometry.getGeometryType() + "' not allowed).");
+                        }
+                        else{
+                            LOGGER.error("The geometry '" + output.getTitle() + "' type is not accepted ('" +
+                                    geometry.getGeometryType() + "' not allowed).");
+                        }
                         dataMap.put(inputOrOutput.getIdentifier(), null);
                         return;
                     }
                     //Read the string to retrieve the Geometry
                     String wkt = new WKTWriter(geometryData.getDimension()).write(geometry);
                     if(wkt == null || wkt.isEmpty()){
-                        pel.appendLog(ProcessExecutionListener.LogType.ERROR,"Unable to read the geometry '" +
-                                output.getTitle() + "'.");
+                        if(pel != null) {
+                            pel.appendLog(ProcessExecutionListener.LogType.ERROR, "Unable to read the geometry '" +
+                                    output.getTitle() + "'.");
+                        }
+                        else{
+                            LOGGER.error("Unable to read the geometry '" + output.getTitle() + "'.");
+                        }
                         dataMap.put(inputOrOutput.getIdentifier(), null);
                         return;
                     }
                     dataMap.put(inputOrOutput.getIdentifier(), wkt);
 
-                    pel.appendLog(ProcessExecutionListener.LogType.INFO,"Output geometry '" +
-                            output.getTitle() + "' is '"+wkt+"'.");
+                    if(pel != null) {
+                        pel.appendLog(ProcessExecutionListener.LogType.INFO, "Output geometry '" +
+                                output.getTitle() + "' is '" + wkt + "'.");
+                    }
                 }
             }
         }

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/execution/LiteralDataProcessing.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/execution/LiteralDataProcessing.java
@@ -32,8 +32,10 @@ public class LiteralDataProcessing implements DataProcessing {
     @Override
     public void postProcessData(DescriptionType inputOrOutput, Map<URI, Object> dataMap, Map<URI, Object> stash, ProcessExecutionListener pel) {
         if(inputOrOutput instanceof Output) {
-            pel.appendLog(ProcessExecutionListener.LogType.INFO, "Literal output : '" +
-                    dataMap.get(inputOrOutput.getIdentifier()) + "'");
+            if(pel != null) {
+                pel.appendLog(ProcessExecutionListener.LogType.INFO, "Literal output : '" +
+                        dataMap.get(inputOrOutput.getIdentifier()) + "'");
+            }
         }
     }
 }

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/execution/RawDataProcessing.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/execution/RawDataProcessing.java
@@ -40,8 +40,10 @@ public class RawDataProcessing implements DataProcessing {
             Output output = (Output) inputOrOutput;
             //Check if the input is a GeometryData
             if(output.getDataDescription() instanceof RawData) {
-                pel.appendLog(ProcessExecutionListener.LogType.INFO,"Output RawData '" +
-                        output.getTitle() + "' is '"+dataMap.get(output.getIdentifier())+"'.");
+                if(pel != null) {
+                    pel.appendLog(ProcessExecutionListener.LogType.INFO, "Output RawData '" +
+                            output.getTitle() + "' is '" + dataMap.get(output.getIdentifier()) + "'.");
+                }
             }
         }
     }

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/model/DataStore.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/model/DataStore.java
@@ -19,6 +19,7 @@
 
 package org.orbisgis.wpsservice.model;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,6 +30,10 @@ import java.util.List;
  **/
 
 public class DataStore extends ComplexData{
+    /**DataStore types.*/
+    public static final String DATASTORE_TYPE_GEOCATALOG = "DATASTORE_TYPE_GEOCATALOG";
+    public static final String DATASTORE_TYPE_FILE = "DATASTORE_TYPE_FILE";
+
     /** True if the data is spatial, false otherwise **/
     private boolean isSpatial;
     /** True if the data can come from the OrbisGIS geocatalog spatial, false otherwise **/
@@ -138,5 +143,27 @@ public class DataStore extends ComplexData{
      */
     public List<DataField> getListDataField(){
         return listDataField;
+    }
+
+    /**
+     * Build an URI usable in the wps service from the dataStore information.
+     * @param dataStoreType Type of the dataStore, can be DATASTORE_TYPE_GEOCATALOG or DATASTORE_TYPE_FILE.
+     * @param dataSource Body of the uri. If it is a file, dataSource is the file absolute path, if it is a geocatalog,
+     *                   dataSource is the table name.
+     * @param tableName Table name.
+     * @return
+     */
+    public static URI buildUriDataStore(String dataStoreType, String dataSource, String tableName){
+        String uri = "";
+        switch(dataStoreType){
+            case DATASTORE_TYPE_GEOCATALOG:
+                uri += "geocatalog:";
+                break;
+            case DATASTORE_TYPE_FILE:
+                uri += "file:";
+        }
+        uri += dataSource;
+        uri += "#"+tableName;
+        return URI.create(uri);
     }
 }

--- a/bundles/wps-service/src/main/resources/org/orbisgis/wpsservice/scripts/insertInto.groovy
+++ b/bundles/wps-service/src/main/resources/org/orbisgis/wpsservice/scripts/insertInto.groovy
@@ -20,7 +20,10 @@ import org.orbisgis.wpsservice.model.LiteralData
  * This process insert the given value in the given table.
  * The user has to specify (mandatory):
  *  - The input table (DataStore)
- *  - The primary keys of the rows to remove (LiteralData)
+ *  - The values to insert (LiteralData)
+ *
+ * The user can specify (optional) :
+ *  - The field list concerned by the value insertion (DataField)
  *
  * @author Sylvain PALOMINOS
  */
@@ -28,12 +31,18 @@ import org.orbisgis.wpsservice.model.LiteralData
         resume = "Insert values into a table.",
         keywords = "OrbisGIS,table_editor")
 def processing() {
-    //Build the start of the query
-    String queryBase = "INSERT INTO " + tableName + "(" + fields + ") VALUES ("
+    //Build the query
+    String queryBase = "INSERT INTO " + tableName;
+    if(fields != null){
+        queryBase += " (" + fields + ") ";
+    }
+    queryBase += " VALUES (";
+    //execute the query for each row
     String[] rowArray = values.split(";")
     for(String row : rowArray){
         String query = queryBase
         String[] valueArray = row.split(",")
+        //Retrieve the values to insert
         String formatedValues = ""
         for(String value : valueArray){
             if(formatedValues.isEmpty()){
@@ -44,7 +53,7 @@ def processing() {
             }
         }
         query += formatedValues + ");"
-        print query
+        //execute the query
         sql.execute(query)
     }
     literalOutput = "Insert done."
@@ -71,7 +80,8 @@ String tableName
         title = "Fields",
         resume = "The field concerned by the value insertion",
         dataStore = "tableName",
-        isMultipleField = true)
+        isMultipleField = true,
+        minOccurs = 0)
 String fields
 
 /** This DataStore is the output data source for the buffer. */

--- a/bundles/wps-service/src/main/resources/org/orbisgis/wpsservice/scripts/insertInto.groovy
+++ b/bundles/wps-service/src/main/resources/org/orbisgis/wpsservice/scripts/insertInto.groovy
@@ -17,7 +17,7 @@ import org.orbisgis.wpsservice.model.LiteralData
 /********************/
 
 /**
- * This process insert the given value in the given table.
+ * This process insert the given values in the given table.
  * The user has to specify (mandatory):
  *  - The input table (DataStore)
  *  - The values to insert (LiteralData)
@@ -87,13 +87,13 @@ String tableName
         minOccurs = 0)
 String fields
 
-/** This DataStore is the output data source for the buffer. */
+/** Coma separated values to insert. */
 @LiteralDataInput(
         title="Values",
         resume="The input values. The values should be separated by a ',' and rows by ';'")
 String values
 
-/** This DataStore is the output data source for the buffer. */
+/** String output of the process. */
 @LiteralDataOutput(
         title="Output message",
         resume="The output message")

--- a/bundles/wps-service/src/main/resources/org/orbisgis/wpsservice/scripts/insertInto.groovy
+++ b/bundles/wps-service/src/main/resources/org/orbisgis/wpsservice/scripts/insertInto.groovy
@@ -17,25 +17,37 @@ import org.orbisgis.wpsservice.model.LiteralData
 /********************/
 
 /**
- * This process removes the given rows from the given table.
+ * This process insert the given value in the given table.
  * The user has to specify (mandatory):
  *  - The input table (DataStore)
- *  - The primary key field (DataField)
- *  - The primary keys of the rows to remove (FieldValue)
+ *  - The primary keys of the rows to remove (LiteralData)
  *
  * @author Sylvain PALOMINOS
  */
-@Process(title = "RemoveRow",
-        resume = "Remove rows from a table.",
+@Process(title = "InsertInto",
+        resume = "Insert values into a table.",
         keywords = "OrbisGIS,table_editor")
 def processing() {
     //Build the start of the query
-    for (String s : pkToRemove) {
-        String query = "DELETE FROM " + tableName + " WHERE " + pkField + " = " + Long.parseLong(s)
-        //Execute the query
+    String queryBase = "INSERT INTO " + tableName + "(" + fields + ") VALUES ("
+    String[] rowArray = values.split(";")
+    for(String row : rowArray){
+        String query = queryBase
+        String[] valueArray = row.split(",")
+        String formatedValues = ""
+        for(String value : valueArray){
+            if(formatedValues.isEmpty()){
+                formatedValues += "'" + value + "'";
+            }
+            else{
+                formatedValues += ",'" + value + "'";
+            }
+        }
+        query += formatedValues + ");"
+        print query
         sql.execute(query)
     }
-    literalOutput = "Remove done."
+    literalOutput = "Insert done."
 }
 
 
@@ -54,22 +66,21 @@ String tableName
 /** INPUT Parameters **/
 /**********************/
 
-/** Name of the PrimaryKey field of the DataStore tableName. */
+/** Field list concerned by the value insertion. */
 @DataFieldInput(
-        title = "PKField",
-        resume = "The primary key field",
-        dataStore = "tableName")
-String pkField
+        title = "Fields",
+        resume = "The field concerned by the value insertion",
+        dataStore = "tableName",
+        isMultipleField = true)
+String fields
 
-/** List of primary keys to remove from the table. */
-@FieldValueInput(
-        title = "PKArray",
-        resume = "The array of the primary keys of the rows to remove",
-        dataField = "pkField",
-        multiSelection = true)
-String[] pkToRemove
+/** This DataStore is the output data source for the buffer. */
+@LiteralDataInput(
+        title="Values",
+        resume="The input values. The values should be separated by a ',' and rows by ';'")
+String values
 
-/** Output message. */
+/** This DataStore is the output data source for the buffer. */
 @LiteralDataOutput(
         title="Output message",
         resume="The output message")

--- a/bundles/wps-service/src/main/resources/org/orbisgis/wpsservice/scripts/insertInto.groovy
+++ b/bundles/wps-service/src/main/resources/org/orbisgis/wpsservice/scripts/insertInto.groovy
@@ -41,15 +41,18 @@ def processing() {
     String[] rowArray = values.split(";")
     for(String row : rowArray){
         String query = queryBase
-        String[] valueArray = row.split(",")
+        String[] valueArray = row.split(",", -1)
         //Retrieve the values to insert
         String formatedValues = ""
         for(String value : valueArray){
-            if(formatedValues.isEmpty()){
-                formatedValues += "'" + value + "'";
+            if(!formatedValues.isEmpty()){
+                formatedValues += ",";
+            }
+            if(value.isEmpty()){
+                formatedValues += "NULL"
             }
             else{
-                formatedValues += ",'" + value + "'";
+                formatedValues += "'" + value + "'";
             }
         }
         query += formatedValues + ");"

--- a/bundles/wps-service/src/main/resources/org/orbisgis/wpsservice/scripts/removeRow.groovy
+++ b/bundles/wps-service/src/main/resources/org/orbisgis/wpsservice/scripts/removeRow.groovy
@@ -1,0 +1,77 @@
+//TODO : header
+
+package org.orbisgis.wpsservice.scripts
+
+import org.orbisgis.wpsgroovyapi.input.DataFieldInput
+import org.orbisgis.wpsgroovyapi.input.DataStoreInput
+import org.orbisgis.wpsgroovyapi.input.EnumerationInput
+import org.orbisgis.wpsgroovyapi.input.FieldValueInput
+import org.orbisgis.wpsgroovyapi.input.LiteralDataInput
+import org.orbisgis.wpsgroovyapi.output.DataStoreOutput
+import org.orbisgis.wpsgroovyapi.output.LiteralDataOutput
+import org.orbisgis.wpsgroovyapi.process.Process
+import org.orbisgis.wpsservice.model.LiteralData
+
+/********************/
+/** Process method **/
+/********************/
+
+/**
+ * This process removes the given row from the given table.
+ * The user has to specify (mandatory):
+ *  - The input table (DataStore)
+ *  - The primary keys of the rows to remove (LiteralData)
+ *
+ * @author Sylvain PALOMINOS
+ */
+@Process(title = "RemoveRow",
+        resume = "Remove rows from a table.",
+        keywords = "OrbisGIS,table_editor")
+def processing() {
+    //Build the start of the query
+    for (String s : pkToRemove) {
+        String query = "DELETE FROM " + tableName + " WHERE " + pkField + " = " + Long.parseLong(s)
+        print query
+        //Execute the query
+        sql.execute(query)
+    }
+    dataStoreOutput = "Remove done."
+}
+
+
+/****************/
+/** INPUT Data **/
+/****************/
+
+/** This DataStore is the input data source for the buffer. */
+@DataStoreInput(
+        title = "Table",
+        resume = "The table to edit",
+        isSpatial = true)
+String tableName
+
+/**********************/
+/** INPUT Parameters **/
+/**********************/
+
+/** Name of the Geometric field of the DataStore inputDataStore. */
+@DataFieldInput(
+        title = "PKField",
+        resume = "The primary key field",
+        dataStore = "tableName")
+String pkField
+
+/** Name of the Geometric field of the DataStore inputDataStore. */
+@FieldValueInput(
+        title = "PKArray",
+        resume = "The array of the primary keys of the rows to remove",
+        dataField = "pkField",
+        multiSelection = true)
+String[] pkToRemove
+
+/** This DataStore is the output data source for the buffer. */
+@LiteralDataOutput(
+        title="Output message",
+        resume="The output message")
+String dataStoreOutput
+

--- a/bundles/wps-service/src/main/resources/org/orbisgis/wpsservice/scripts/removeRow.groovy
+++ b/bundles/wps-service/src/main/resources/org/orbisgis/wpsservice/scripts/removeRow.groovy
@@ -31,7 +31,6 @@ def processing() {
     //Build the start of the query
     for (String s : pkToRemove) {
         String query = "DELETE FROM " + tableName + " WHERE " + pkField + " = " + Long.parseLong(s)
-        print query
         //Execute the query
         sql.execute(query)
     }


### PR DESCRIPTION
Makes the AddRow and RemoveRow actions from the table-editor use wps scripts to do the action. (issue #959)

 - On the process execution, the ProcessExecutionListener can be null. (The messages will be log in the orbisgis log.)
 - Creates the process InsertInto and RemoveRow
 - Replaces the java call in the AddRowAction and RemoveRowAction by call to wps scripts.