### PR TITLE
Fixes the table column sort. (issue #981)

### DIFF
--- a/bundles/core-jdbc/src/main/java/org/orbisgis/corejdbc/ReadTable.java
+++ b/bundles/core-jdbc/src/main/java/org/orbisgis/corejdbc/ReadTable.java
@@ -87,7 +87,7 @@ public class ReadTable {
             try {
                 int pkIndex = JDBCUtilities.getIntegerPrimaryKey(connection, tableLocation.toString());
                 if (pkIndex > 0) {
-                    ProgressMonitor jobProgress = progressMonitor.startTask(2);
+                    ProgressMonitor jobProgress = progressMonitor.startTask(1);
                     // Do not cache values
                     // Use SQL sort
                     DatabaseMetaData meta = connection.getMetaData();
@@ -96,22 +96,11 @@ public class ReadTable {
                     if(!ascending) {
                         desc = " DESC";
                     }
-                    // Create a map of Row Id to Pk Value
-                    ProgressMonitor cacheProgress = jobProgress.startTask(I18N.tr("Cache primary key values"), rowCount);
-                    Map<Long, Integer> pkValueToRowId = new HashMap<>(rowCount);
-                    int rowId=0;
-                    try(ResultSet rs = st.executeQuery("select "+pkFieldName+" from "+table)) {
-                        while(rs.next()) {
-                            rowId++;
-                            pkValueToRowId.put(rs.getLong(1), rowId);
-                            cacheProgress.endTask();
-                        }
-                    }
                     // Read ordered pk values
                     ProgressMonitor sortProgress = jobProgress.startTask(I18N.tr("Read sorted keys"), rowCount);
                     try(ResultSet rs = st.executeQuery("select "+pkFieldName+" from "+table+" ORDER BY "+columnName+desc)) {
                         while(rs.next()) {
-                            columnValues.add(pkValueToRowId.get(rs.getLong(1)));
+                            columnValues.add((int)rs.getLong(1));
                             sortProgress.endTask();
                         }
                     }

--- a/bundles/core-jdbc/src/test/java/org/orbisgis/corejdbc/JDBCUtilityTest.java
+++ b/bundles/core-jdbc/src/test/java/org/orbisgis/corejdbc/JDBCUtilityTest.java
@@ -110,19 +110,19 @@ public class JDBCUtilityTest {
                 // Test ascending
                 Collection<Integer> sortedRowId = ReadTable.getSortedColumnRowIndex(connection, "INTTABLE", "vals", true, new NullProgressMonitor());
                 Iterator<Integer> itTest = sortedRowId.iterator();
-                assertEquals(5, itTest.next().intValue());
-                assertEquals(4, itTest.next().intValue());
+                assertEquals(16, itTest.next().intValue());
+                assertEquals(8, itTest.next().intValue());
                 assertEquals(2, itTest.next().intValue());
-                assertEquals(3, itTest.next().intValue());
+                assertEquals(4, itTest.next().intValue());
                 assertEquals(1, itTest.next().intValue());
                 // Test descending
                 sortedRowId = ReadTable.getSortedColumnRowIndex(connection, "INTTABLE", "vals", false, new NullProgressMonitor());
                 itTest = sortedRowId.iterator();
                 assertEquals(1, itTest.next().intValue());
-                assertEquals(3, itTest.next().intValue());
-                assertEquals(2, itTest.next().intValue());
                 assertEquals(4, itTest.next().intValue());
-                assertEquals(5, itTest.next().intValue());
+                assertEquals(2, itTest.next().intValue());
+                assertEquals(8, itTest.next().intValue());
+                assertEquals(16, itTest.next().intValue());
             } finally {
                 st.execute("DROP TABLE inttable IF EXISTS");
             }
@@ -139,18 +139,18 @@ public class JDBCUtilityTest {
             Collection<Integer> sortedRowId = ReadTable.getSortedColumnRowIndex(connection, "INTTABLE", "vals", true, new NullProgressMonitor());
             Iterator<Integer> itTest = sortedRowId.iterator();
             assertEquals(2, itTest.next().intValue());
-            assertEquals(5, itTest.next().intValue());
+            assertEquals(16, itTest.next().intValue());
+            assertEquals(8, itTest.next().intValue());
             assertEquals(4, itTest.next().intValue());
-            assertEquals(3, itTest.next().intValue());
             assertEquals(1, itTest.next().intValue());
             // Test descending
             sortedRowId = ReadTable.getSortedColumnRowIndex(connection, "INTTABLE", "vals", false, new NullProgressMonitor());
             itTest = sortedRowId.iterator();
             assertEquals(1, itTest.next().intValue());
-            assertEquals(3, itTest.next().intValue());
             assertEquals(4, itTest.next().intValue());
+            assertEquals(8, itTest.next().intValue());
             assertEquals(2, itTest.next().intValue());
-            assertEquals(5, itTest.next().intValue());
+            assertEquals(16, itTest.next().intValue());
         }
     }
 


### PR DESCRIPTION
Fixes the column sorting on a postgis table.
Updates the ReadTable class to get the value pk instead of the value row id.
Also increase the sort speed.