### PR TITLE
WPS annotation test

### DIFF
--- a/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/attributes/DescriptionTypeAttribute.groovy
+++ b/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/attributes/DescriptionTypeAttribute.groovy
@@ -32,10 +32,16 @@ import java.lang.annotation.RetentionPolicy
  *       Title of a process, input, and output. Normally available for display to a human.
  *
  * The following fields can be defined (optional) :
+ *  - traducedTitles : LanguageString[]
+ *      List of LanguageString containing the traduced titles.
  *  - resume : String
- *      Brief narrative description of a process, input, and output. Normally available for display to a human..
+ *      Brief narrative description of a process, input, and output. Normally available for display to a human.
+ *  - traducedResumes : LanguageString[]
+ *      List of LanguageString containing the traduced description.
  *  - keywords : String
- *      Coma separated keywords that characterize a process, its inputs, and outputs.
+ *      Array of keywords that characterize a process, its inputs, and outputs.
+ *  - traducedKeywords : Keyword[]
+ *      List of Keyword containing the keywords translations.
  *  - identifier : String
  *      Unambiguous identifier of a process, input, and output. It should be a valid URI.
  *  - metadata : MetaData[]
@@ -49,11 +55,20 @@ import java.lang.annotation.RetentionPolicy
     /** Title of a process, input, and output. Normally available for display to a human. */
     String title()
 
+    /** List of LanguageString containing the traduced titles. */
+    LanguageString[] traducedTitles() default []
+
     /** Brief narrative description of a process, input, and output. Normally available for display to a human. */
     String resume() default ""
 
-    /** Coma separated keywords that characterize a process, its inputs, and outputs. */
-    String keywords() default ""
+    /** List of LanguageString containing the traduced description. */
+    LanguageString[] traducedResumes() default []
+
+    /** Array of keywords that characterize a process, its inputs, and outputs. */
+    String[] keywords() default []
+
+    /** List of Keyword containing the keywords translations. */
+    Keyword[] traducedKeywords() default []
 
     /** Unambiguous identifier of a process, input, and output. */
     String identifier() default ""
@@ -66,8 +81,11 @@ import java.lang.annotation.RetentionPolicy
     /********************/
     /** default values **/
     /********************/
+    public static final LanguageString[] defaultTraducedTitles = []
     public static final String defaultResume = ""
-    public static final String defaultKeywords = ""
+    public static final LanguageString[] defaultTraducedResumes = []
+    public static final String[] defaultKeywords = []
+    public static final Keyword[] defaultTraducedKeywords = []
     public static final String defaultIdentifier = ""
     public static final MetadataAttribute[] defaultMetadata = []
 }

--- a/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/attributes/Keyword.groovy
+++ b/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/attributes/Keyword.groovy
@@ -1,0 +1,16 @@
+package org.orbisgis.wpsgroovyapi.attributes
+
+/**
+ * @author Sylvain PALOMINOS
+ */
+
+@interface Keyword {
+    /** List of LanguagesString containing the traduced keywords. */
+    LanguageString[] traducedKeywords() default []
+
+
+    /********************/
+    /** default values **/
+    /********************/
+    public static final LanguageString[] defaultTraducedKeywords = []
+}

--- a/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/attributes/LanguageString.groovy
+++ b/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/attributes/LanguageString.groovy
@@ -1,0 +1,11 @@
+package org.orbisgis.wpsgroovyapi.attributes
+
+/**
+ * @author Sylvain PALOMINOS
+ */
+@interface LanguageString {
+    /** Traduced value of the LanguageString. */
+    String value()
+    /** Language of the traduced string. */
+    String lang()
+}

--- a/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/input/DataFieldInput.groovy
+++ b/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/input/DataFieldInput.groovy
@@ -47,10 +47,16 @@ import org.orbisgis.wpsgroovyapi.attributes.InputAttribute
  *      The variable name that contains the DataStore.
  *
  * The following fields can be defined (optional) :
+ *  - traducedTitles : LanguageString[]
+ *      List of LanguageString containing the traduced titles.
  *  - resume : String
  *      Brief narrative description of the input. Normally available for display to a human.
+ *  - traducedResumes : LanguageString[]
+ *      List of LanguageString containing the traduced description.
  *  - keywords : String
- *      Coma separated keywords that characterize the input.
+ *      Array of keywords that characterize the input.
+ *  - traducedKeywords : Keyword[]
+ *      List of Keyword containing the keywords translations.
  *  - identifier : String
  *      Unambiguous identifier of the input. It should be a valid URI.
  *  - metadata : MetaData[]

--- a/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/input/DataStoreInput.groovy
+++ b/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/input/DataStoreInput.groovy
@@ -45,10 +45,16 @@ import org.orbisgis.wpsgroovyapi.attributes.InputAttribute
  *       Title of the input. Normally available for display to a human.
  *
  * The following fields can be defined (optional) :
+ *  - traducedTitles : LanguageString[]
+ *      List of LanguageString containing the traduced titles.
  *  - resume : String
  *      Brief narrative description of the input. Normally available for display to a human.
+ *  - traducedResumes : LanguageString[]
+ *      List of LanguageString containing the traduced description.
  *  - keywords : String
- *      Coma separated keywords that characterize the input.
+ *      Array of keywords that characterize the input.
+ *  - traducedKeywords : Keyword[]
+ *      List of Keyword containing the keywords translations.
  *  - identifier : String
  *      Unambiguous identifier of the input. It should be a valid URI.
  *  - metadata : MetaData[]

--- a/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/input/EnumerationInput.groovy
+++ b/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/input/EnumerationInput.groovy
@@ -47,10 +47,16 @@ import org.orbisgis.wpsgroovyapi.attributes.InputAttribute
  *      List of possible values.
  *
  * The following fields can be defined (optional) :
+ *  - traducedTitles : LanguageString[]
+ *      List of LanguageString containing the traduced titles.
  *  - resume : String
  *      Brief narrative description of the input. Normally available for display to a human.
+ *  - traducedResumes : LanguageString[]
+ *      List of LanguageString containing the traduced description.
  *  - keywords : String
- *      Coma separated keywords that characterize the input.
+ *      Array of keywords that characterize the input.
+ *  - traducedKeywords : Keyword[]
+ *      List of Keyword containing the keywords translations.
  *  - identifier : String
  *      Unambiguous identifier of the input. It should be a valid URI.
  *  - metadata : MetaData[]

--- a/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/input/FieldValueInput.groovy
+++ b/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/input/FieldValueInput.groovy
@@ -47,10 +47,16 @@ import org.orbisgis.wpsgroovyapi.attributes.InputAttribute
  *      Name of the variable which is the dataStore.
  *
  * The following fields can be defined (optional) :
+ *  - traducedTitles : LanguageString[]
+ *      List of LanguageString containing the traduced titles.
  *  - resume : String
  *      Brief narrative description of the input. Normally available for display to a human.
+ *  - traducedResumes : LanguageString[]
+ *      List of LanguageString containing the traduced description.
  *  - keywords : String
- *      Coma separated keywords that characterize the input.
+ *      Array of keywords that characterize the input.
+ *  - traducedKeywords : Keyword[]
+ *      List of Keyword containing the keywords translations.
  *  - identifier : String
  *      Unambiguous identifier of the input. It should be a valid URI.
  *  - metadata : MetaData[]

--- a/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/input/GeometryInput.groovy
+++ b/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/input/GeometryInput.groovy
@@ -45,10 +45,16 @@ import org.orbisgis.wpsgroovyapi.attributes.GeometryAttribute
  *       Title of the input. Normally available for display to a human.
  *
  * The following fields can be defined (optional) :
+ *  - traducedTitles : LanguageString[]
+ *      List of LanguageString containing the traduced titles.
  *  - resume : String
  *      Brief narrative description of the input. Normally available for display to a human.
+ *  - traducedResumes : LanguageString[]
+ *      List of LanguageString containing the traduced description.
  *  - keywords : String
- *      Coma separated keywords that characterize the input.
+ *      Array of keywords that characterize the input.
+ *  - traducedKeywords : Keyword[]
+ *      List of Keyword containing the keywords translations.
  *  - identifier : String
  *      Unambiguous identifier of the input. It should be a valid URI.
  *  - metadata : MetaData[]

--- a/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/input/LiteralDataInput.groovy
+++ b/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/input/LiteralDataInput.groovy
@@ -45,10 +45,16 @@ import org.orbisgis.wpsgroovyapi.attributes.LiteralDataAttribute
  *       Title of the input. Normally available for display to a human.
  *
  * The following fields can be defined (optional) :
+ *  - traducedTitles : LanguageString[]
+ *      List of LanguageString containing the traduced titles.
  *  - resume : String
  *      Brief narrative description of the input. Normally available for display to a human.
+ *  - traducedResumes : LanguageString[]
+ *      List of LanguageString containing the traduced description.
  *  - keywords : String
- *      Coma separated keywords that characterize the input.
+ *      Array of keywords that characterize the input.
+ *  - traducedKeywords : Keyword[]
+ *      List of Keyword containing the keywords translations.
  *  - identifier : String
  *      Unambiguous identifier of the input. It should be a valid URI.
  *  - metadata : MetaData[]

--- a/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/input/RawDataInput.groovy
+++ b/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/input/RawDataInput.groovy
@@ -45,10 +45,16 @@ import org.orbisgis.wpsgroovyapi.attributes.InputAttribute
  *       Title of the input. Normally available for display to a human.
  *
  * The following fields can be defined (optional) :
+ *  - traducedTitles : LanguageString[]
+ *      List of LanguageString containing the traduced titles.
  *  - resume : String
  *      Brief narrative description of the input. Normally available for display to a human.
+ *  - traducedResumes : LanguageString[]
+ *      List of LanguageString containing the traduced description.
  *  - keywords : String
- *      Coma separated keywords that characterize the input.
+ *      Array of keywords that characterize the input.
+ *  - traducedKeywords : Keyword[]
+ *      List of Keyword containing the keywords translations.
  *  - identifier : String
  *      Unambiguous identifier of the input. It should be a valid URI.
  *  - metadata : MetaData[]

--- a/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/output/DataFieldOutput.groovy
+++ b/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/output/DataFieldOutput.groovy
@@ -37,10 +37,16 @@ import org.orbisgis.wpsgroovyapi.attributes.DescriptionTypeAttribute
  *      The variable name that contains the DataStore.
  *
  * The following fields can be defined (optional) :
+ *  - traducedTitles : LanguageString[]
+ *      List of LanguageString containing the traduced titles.
  *  - resume : String
- *      Brief narrative description of the output. Normally available for display to a human..
+ *      Brief narrative description of the output. Normally available for display to a human.
+ *  - traducedResumes : LanguageString[]
+ *      List of LanguageString containing the traduced description.
  *  - keywords : String
- *      Coma separated keywords that characterize the output.
+ *      Array of keywords that characterize the output.
+ *  - traducedKeywords : Keyword[]
+ *      List of Keyword containing the keywords translations.
  *  - identifier : String
  *      Unambiguous identifier of the output. It should be a valid URI.
  *  - metadata : MetaData[]

--- a/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/output/DataStoreOutput.groovy
+++ b/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/output/DataStoreOutput.groovy
@@ -35,10 +35,16 @@ import org.orbisgis.wpsgroovyapi.attributes.OutputAttribute
  *       Title of the output. Normally available for display to a human.
  *
  * The following fields can be defined (optional) :
+ *  - traducedTitles : LanguageString[]
+ *      List of LanguageString containing the traduced titles.
  *  - resume : String
- *      Brief narrative description of the output. Normally available for display to a human..
+ *      Brief narrative description of the output. Normally available for display to a human.
+ *  - traducedResumes : LanguageString[]
+ *      List of LanguageString containing the traduced description.
  *  - keywords : String
- *      Coma separated keywords that characterize the output.
+ *      Array of keywords that characterize the output.
+ *  - traducedKeywords : Keyword[]
+ *      List of Keyword containing the keywords translations.
  *  - identifier : String
  *      Unambiguous identifier of the output. It should be a valid URI.
  *  - metadata : MetaData[]

--- a/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/output/EnumerationOutput.groovy
+++ b/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/output/EnumerationOutput.groovy
@@ -37,10 +37,16 @@ import org.orbisgis.wpsgroovyapi.attributes.DescriptionTypeAttribute
  *      List of possible values.
  *
  * The following fields can be defined (optional) :
+ *  - traducedTitles : LanguageString[]
+ *      List of LanguageString containing the traduced titles.
  *  - resume : String
- *      Brief narrative description of the output. Normally available for display to a human..
+ *      Brief narrative description of the output. Normally available for display to a human.
+ *  - traducedResumes : LanguageString[]
+ *      List of LanguageString containing the traduced description.
  *  - keywords : String
- *      Coma separated keywords that characterize the output.
+ *      Array of keywords that characterize the output.
+ *  - traducedKeywords : Keyword[]
+ *      List of Keyword containing the keywords translations.
  *  - identifier : String
  *      Unambiguous identifier of the output. It should be a valid URI.
  *  - metadata : MetaData[]

--- a/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/output/FieldValueOutput.groovy
+++ b/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/output/FieldValueOutput.groovy
@@ -37,10 +37,16 @@ import org.orbisgis.wpsgroovyapi.attributes.OutputAttribute
  *      Name of the variable which is the dataStore.
  *
  * The following fields can be defined (optional) :
+ *  - traducedTitles : LanguageString[]
+ *      List of LanguageString containing the traduced titles.
  *  - resume : String
- *      Brief narrative description of the output. Normally available for display to a human..
+ *      Brief narrative description of the output. Normally available for display to a human.
+ *  - traducedResumes : LanguageString[]
+ *      List of LanguageString containing the traduced description.
  *  - keywords : String
- *      Coma separated keywords that characterize the output.
+ *      Array of keywords that characterize the output.
+ *  - traducedKeywords : Keyword[]
+ *      List of Keyword containing the keywords translations.
  *  - identifier : String
  *      Unambiguous identifier of the output. It should be a valid URI.
  *  - metadata : MetaData[]

--- a/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/output/GeometryOutput.groovy
+++ b/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/output/GeometryOutput.groovy
@@ -35,10 +35,16 @@ import org.orbisgis.wpsgroovyapi.attributes.GeometryAttribute
  *       Title of the output. Normally available for display to a human.
  *
  * The following fields can be defined (optional) :
+ *  - traducedTitles : LanguageString[]
+ *      List of LanguageString containing the traduced titles.
  *  - resume : String
- *      Brief narrative description of the output. Normally available for display to a human..
+ *      Brief narrative description of the output. Normally available for display to a human.
+ *  - traducedResumes : LanguageString[]
+ *      List of LanguageString containing the traduced description.
  *  - keywords : String
- *      Coma separated keywords that characterize the output.
+ *      Array of keywords that characterize the output.
+ *  - traducedKeywords : Keyword[]
+ *      List of Keyword containing the keywords translations.
  *  - identifier : String
  *      Unambiguous identifier of the output. It should be a valid URI.
  *  - metadata : MetaData[]

--- a/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/output/LiteralDataOutput.groovy
+++ b/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/output/LiteralDataOutput.groovy
@@ -37,10 +37,16 @@ import org.orbisgis.wpsgroovyapi.attributes.LiteralDataAttribute
  *      Information about the literal value.
  *
  * The following fields can be defined (optional) :
+ *  - traducedTitles : LanguageString[]
+ *      List of LanguageString containing the traduced titles.
  *  - resume : String
- *      Brief narrative description of the output. Normally available for display to a human..
+ *      Brief narrative description of the output. Normally available for display to a human.
+ *  - traducedResumes : LanguageString[]
+ *      List of LanguageString containing the traduced description.
  *  - keywords : String
- *      Coma separated keywords that characterize the output.
+ *      Array of keywords that characterize the output.
+ *  - traducedKeywords : Keyword[]
+ *      List of Keyword containing the keywords translations.
  *  - identifier : String
  *      Unambiguous identifier of the output. It should be a valid URI.
  *  - metadata : MetaData[]

--- a/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/output/RawDataOutput.groovy
+++ b/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/output/RawDataOutput.groovy
@@ -35,10 +35,16 @@ import org.orbisgis.wpsgroovyapi.attributes.RawDataAttribute
  *       Title of the output. Normally available for display to a human.
  *
  * The following fields can be defined (optional) :
+ *  - traducedTitles : LanguageString[]
+ *      List of LanguageString containing the traduced titles.
  *  - resume : String
- *      Brief narrative description of the output. Normally available for display to a human..
+ *      Brief narrative description of the output. Normally available for display to a human.
+ *  - traducedResumes : LanguageString[]
+ *      List of LanguageString containing the traduced description.
  *  - keywords : String
- *      Coma separated keywords that characterize the output.
+ *      Array of keywords that characterize the output.
+ *  - traducedKeywords : Keyword[]
+ *      List of Keyword containing the keywords translations.
  *  - identifier : String
  *      Unambiguous identifier of the output. It should be a valid URI.
  *  - metadata : MetaData[]

--- a/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/process/Process.groovy
+++ b/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/process/Process.groovy
@@ -43,10 +43,16 @@ import org.orbisgis.wpsgroovyapi.attributes.ProcessAttribute
  *       Title of the process. Normally available for display to a human.
  *
  * The following fields can be defined (optional) :
+ *  - traducedTitles : LanguageString[]
+ *      List of LanguageString containing the traduced titles.
  *  - resume : String
- *      Brief narrative description of the process. Normally available for display to a human..
+ *      Brief narrative description of the process. Normally available for display to a human.
+ *  - traducedResumes : LanguageString[]
+ *      List of LanguageString containing the traduced description.
  *  - keywords : String
- *      Coma separated keywords that characterize the process.
+ *      Array of keywords that characterize the process.
+ *  - traducedKeywords : Keyword[]
+ *      List of Keyword containing the keywords translations.
  *  - identifier : String
  *      Unambiguous identifier of the process. It should be a valid URI.
  *  - metadata : MetaData[]

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/utils/ObjectAnnotationConverter.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/utils/ObjectAnnotationConverter.java
@@ -140,7 +140,6 @@ public class ObjectAnnotationConverter {
         format.setMimeType(formatAttribute.mimeType());
         format.setSchema(URI.create(formatAttribute.schema()).toString());
         format.setDefault(formatAttribute.isDefaultFormat());
-        format.setMaximumMegabytes(BigInteger.valueOf(formatAttribute.maximumMegaBytes()));
         if(formatAttribute.maximumMegaBytes() == FormatAttribute.defaultMaximumMegaBytes) {
             format.setMaximumMegabytes(null);
         }
@@ -160,6 +159,7 @@ public class ObjectAnnotationConverter {
         metadata.setHref(href.toString());
         metadata.setRole(role.toString());
         metadata.setTitle(title);
+        metadata.setTYPE(TypeType.SIMPLE);
 
         return metadata;
     }

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/utils/ObjectAnnotationConverter.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/utils/ObjectAnnotationConverter.java
@@ -166,11 +166,14 @@ public class ObjectAnnotationConverter {
 
     public static Object annotationToObject(ValuesAttribute valueAttribute){
         if(valueAttribute.type().equals(ValuesType.VALUE)){
+            if(valueAttribute.value().equals(ValuesAttribute.defaultValue)){
+                return null;
+            }
             ValueType value = new ValueType();
             value.setValue(valueAttribute.value());
             return value;
         }
-        else{
+        else if(valueAttribute.type().equals(ValuesType.RANGE)){
             RangeType range = new RangeType();
             if(!valueAttribute.spacing().equals(ValuesAttribute.defaultSpacing)) {
                 ValueType spacing = new ValueType();
@@ -189,6 +192,7 @@ public class ObjectAnnotationConverter {
             }
             return range;
         }
+        return null;
     }
 
     public static LiteralDataDomain annotationToObject(LiteralDataDomainAttribute literalDataDomainAttribute){

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/utils/ObjectAnnotationConverter.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/utils/ObjectAnnotationConverter.java
@@ -172,17 +172,21 @@ public class ObjectAnnotationConverter {
         }
         else{
             RangeType range = new RangeType();
-            if(!valueAttribute.spacing().isEmpty()) {
+            if(!valueAttribute.spacing().equals(ValuesAttribute.defaultSpacing)) {
                 ValueType spacing = new ValueType();
                 spacing.setValue(valueAttribute.spacing());
                 range.setSpacing(spacing);
             }
-            ValueType max = new ValueType();
-            max.setValue(valueAttribute.maximum());
-            range.setMaximumValue(max);
-            ValueType min = new ValueType();
-            min.setValue(valueAttribute.minimum());
-            range.setMinimumValue(min);
+            if(!valueAttribute.maximum().equals(ValuesAttribute.defaultMaximum)){
+                ValueType max = new ValueType();
+                max.setValue(valueAttribute.maximum());
+                range.setMaximumValue(max);
+            }
+            if(!valueAttribute.minimum().equals(ValuesAttribute.defaultMinimum)){
+                ValueType min = new ValueType();
+                min.setValue(valueAttribute.minimum());
+                range.setMinimumValue(min);
+            }
             return range;
         }
     }

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/utils/ObjectAnnotationConverter.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/utils/ObjectAnnotationConverter.java
@@ -24,12 +24,13 @@ import net.opengis.wps.v_2_0.*;
 import net.opengis.wps.v_2_0.DescriptionType;
 import net.opengis.wps.v_2_0.Format;
 import net.opengis.wps.v_2_0.LiteralDataType.LiteralDataDomain;
+import org.hisrc.w3c.xlink.v_1_0.TypeType;
 import org.orbisgis.wpsgroovyapi.attributes.*;
 import org.orbisgis.wpsservice.model.*;
-import org.orbisgis.wpsservice.model.LiteralValue;
 import org.slf4j.LoggerFactory;
 
-import java.lang.annotation.IncompleteAnnotationException;
+import javax.xml.bind.JAXBElement;
+import javax.xml.namespace.QName;
 import java.lang.reflect.Method;
 import java.math.BigInteger;
 import java.net.URI;
@@ -48,14 +49,35 @@ public class ObjectAnnotationConverter {
 
     public static void annotationToObject(DescriptionTypeAttribute descriptionTypeAttribute,
                                           DescriptionType descriptionType){
-        if(!descriptionTypeAttribute.title().equals("")){
+        if(descriptionTypeAttribute.traducedTitles().length != DescriptionTypeAttribute.defaultTraducedTitles.length){
+            List<LanguageStringType> titleList = new ArrayList<>();
+            for(LanguageString languageString : descriptionTypeAttribute.traducedTitles()){
+                LanguageStringType title = new LanguageStringType();
+                title.setValue(languageString.value());
+                title.setLang(languageString.lang());
+                titleList.add(title);
+            }
+            descriptionType.setTitle(titleList);
+        }
+        else if(!descriptionTypeAttribute.title().equals("")){
             List<LanguageStringType> titleList = new ArrayList<>();
             LanguageStringType title = new LanguageStringType();
             title.setValue(descriptionTypeAttribute.title());
             titleList.add(title);
             descriptionType.setTitle(titleList);
         }
-        if(!descriptionTypeAttribute.resume().equals(DescriptionTypeAttribute.defaultResume)){
+
+        if(descriptionTypeAttribute.traducedResumes().length != DescriptionTypeAttribute.defaultTraducedResumes.length) {
+            List<LanguageStringType> resumeList = new ArrayList<>();
+            for(LanguageString languageString : descriptionTypeAttribute.traducedResumes()){
+                LanguageStringType resume = new LanguageStringType();
+                resume.setValue(languageString.value());
+                resume.setLang(languageString.lang());
+                resumeList.add(resume);
+            }
+            descriptionType.setAbstract(resumeList);
+        }
+        else if(!descriptionTypeAttribute.resume().equals(DescriptionTypeAttribute.defaultResume)){
             List<LanguageStringType> resumeList = new ArrayList<>();
             LanguageStringType resume = new LanguageStringType();
             resume.setValue(descriptionTypeAttribute.resume());
@@ -67,9 +89,27 @@ public class ObjectAnnotationConverter {
             codeType.setValue(descriptionTypeAttribute.identifier());
             descriptionType.setIdentifier(codeType);
         }
-        if(!descriptionTypeAttribute.keywords().equals(DescriptionTypeAttribute.defaultKeywords)){
+
+        if(descriptionTypeAttribute.traducedKeywords().length !=
+                DescriptionTypeAttribute.defaultTraducedKeywords.length) {
+            List<KeywordsType> keywordTypeList = new ArrayList<>();
+            for(Keyword keyword : descriptionTypeAttribute.traducedKeywords()) {
+                KeywordsType keywordsType = new KeywordsType();
+                List<LanguageStringType> keywordList = new ArrayList<>();
+                for (LanguageString languageString : keyword.traducedKeywords()) {
+                    LanguageStringType keywordString = new LanguageStringType();
+                    keywordString.setValue(languageString.value());
+                    keywordString.setLang(languageString.lang());
+                    keywordList.add(keywordString);
+                }
+                keywordsType.setKeyword(keywordList);
+                keywordTypeList.add(keywordsType);
+            }
+            descriptionType.setKeywords(keywordTypeList);
+        }
+        else if(descriptionTypeAttribute.keywords().length != DescriptionTypeAttribute.defaultKeywords.length){
             List<KeywordsType> keywordList = new ArrayList<>();
-            for(String key : descriptionTypeAttribute.keywords().split(",")){
+            for(String key : descriptionTypeAttribute.keywords()){
                 KeywordsType keyword = new KeywordsType();
                 List<LanguageStringType> stringList = new ArrayList<>();
                 LanguageStringType string = new LanguageStringType();
@@ -80,7 +120,19 @@ public class ObjectAnnotationConverter {
             }
             descriptionType.setKeywords(keywordList);
         }
-        //TODO : implements for metadata.
+        if(descriptionTypeAttribute.metadata().length != DescriptionTypeAttribute.defaultMetadata.length){
+            List<JAXBElement<? extends MetadataType>> metadataList = new ArrayList<>();
+            QName qname = new QName("http://orbisgis.org", "metadata");
+            for(MetadataAttribute metadataAttribute : descriptionTypeAttribute.metadata()){
+                MetadataType metadataType = new MetadataType();
+                metadataType.setHref(metadataAttribute.href());
+                metadataType.setRole(metadataAttribute.role());
+                metadataType.setTitle(metadataAttribute.title());
+                metadataType.setTYPE(TypeType.SIMPLE);
+                metadataList.add(new JAXBElement<>(qname, MetadataType.class, metadataType));
+            }
+            descriptionType.setMetadata(metadataList);
+        }
     }
 
     public static Format annotationToObject(FormatAttribute formatAttribute){

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/utils/ObjectAnnotationConverter.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/utils/ObjectAnnotationConverter.java
@@ -141,6 +141,13 @@ public class ObjectAnnotationConverter {
         format.setSchema(URI.create(formatAttribute.schema()).toString());
         format.setDefault(formatAttribute.isDefaultFormat());
         format.setMaximumMegabytes(BigInteger.valueOf(formatAttribute.maximumMegaBytes()));
+        if(formatAttribute.maximumMegaBytes() == FormatAttribute.defaultMaximumMegaBytes) {
+            format.setMaximumMegabytes(null);
+        }
+        else{
+            format.setMaximumMegabytes(BigInteger.valueOf(formatAttribute.maximumMegaBytes()));
+        }
+        format.setEncoding(formatAttribute.encoding());
         return format;
     }
 

--- a/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/controller/utils/DescriptionTypeConvertTest.java
+++ b/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/controller/utils/DescriptionTypeConvertTest.java
@@ -1,0 +1,684 @@
+package org.orbisgis.wpsservice.controller.utils;
+
+import net.opengis.ows.v_2_0.CodeType;
+import net.opengis.ows.v_2_0.KeywordsType;
+import net.opengis.ows.v_2_0.LanguageStringType;
+import net.opengis.ows.v_2_0.MetadataType;
+import org.hisrc.w3c.xlink.v_1_0.TypeType;
+import org.junit.Assert;
+import org.junit.Test;
+import org.orbisgis.wpsgroovyapi.attributes.DescriptionTypeAttribute;
+import net.opengis.wps.v_2_0.DescriptionType;
+import org.orbisgis.wpsgroovyapi.attributes.Keyword;
+import org.orbisgis.wpsgroovyapi.attributes.LanguageString;
+import org.orbisgis.wpsgroovyapi.attributes.MetadataAttribute;
+
+import javax.xml.bind.JAXBElement;
+import javax.xml.namespace.QName;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This test class perform three test on the DescriptionType annotation parsing.
+ * The test are done on converting a @DescriptionTypeAttribute annotation into the model java object.
+ * Each test are done on different annotation complexity : a full annotation, a simple and a minimal one.
+ *
+ * @author Sylvain PALOMINOS
+ */
+public class DescriptionTypeConvertTest {
+
+    /*************************
+     * FULL DESCRIPTION TYPE *
+     *************************/
+
+    /** Field containing the full DescriptionTypeAttribute annotation. */
+    @DescriptionTypeAttribute(
+            title = "DescriptionType attribute title",
+            traducedTitles = {
+                    @LanguageString(value = "DescriptionType attribute title", lang = "en"),
+                    @LanguageString(value = "Titre de l'attribut DescriptionType", lang = "fr")
+            },
+            resume = "DescriptionType attribute resume",
+            traducedResumes = {
+                    @LanguageString(value = "DescriptionType attribute resume", lang = "en"),
+                    @LanguageString(value = "Description de l'attribut DescriptionType", lang = "fr")
+            },
+            keywords = {"DescriptionType","Attribute"},
+            traducedKeywords = {
+                    @Keyword(traducedKeywords = {
+                            @LanguageString(value = "Attribute en", lang = "en"),
+                            @LanguageString(value = "Attribute fr", lang = "fr")
+                    }),
+                    @Keyword(traducedKeywords = {
+                            @LanguageString(value = "DescriptionType en", lang = "en"),
+                            @LanguageString(value = "DescriptionType fr", lang = "fr")
+                    })
+            },
+            identifier = "test:descriptionTypeAttribute",
+            metadata = {
+                    @MetadataAttribute(title = "metadata1", linkType = "simple", role = "role1", href = "href1"),
+                    @MetadataAttribute(title = "metadata2", linkType = "simple", role = "role2", href = "href2")
+            }
+    )
+    public Object fullDescriptionTypeAttribute;
+    /** Name of the field containing the fullDescriptionTypeAttribute annotation. */
+    private static final String FULL_DESCRIPTION_TYPE_ATTRIBUTE_FIELD_NAME = "fullDescriptionTypeAttribute";
+
+    /**
+     * Test if the decoding and convert of the full DescriptionTypeAttribute annotation into its java object is valid.
+     */
+    @Test
+    public void testFullDescriptionTypeAttributeConvert(){
+        try {
+            boolean annotationFound = false;
+            //Retrieve the DescriptionType object
+            DescriptionType descriptionType = new DescriptionType();
+            //Inspect all the annotation of the field to get the DescriptionTypeAttribute one
+            Field descriptionTypeField = this.getClass().getDeclaredField(FULL_DESCRIPTION_TYPE_ATTRIBUTE_FIELD_NAME);
+            for(Annotation annotation : descriptionTypeField.getDeclaredAnnotations()){
+                //Once the annotation is get, decode it.
+                if(annotation instanceof DescriptionTypeAttribute){
+                    annotationFound = true;
+                    DescriptionTypeAttribute descriptionTypeAnnotation = (DescriptionTypeAttribute) annotation;
+                    ObjectAnnotationConverter.annotationToObject(descriptionTypeAnnotation, descriptionType);
+                }
+            }
+
+            //If the annotation hasn't been found, the test has failed.
+            if(!annotationFound){
+                Assert.fail("Unable to get the annotation '@DescriptionTypeAttribute' from the field '" +
+                        FULL_DESCRIPTION_TYPE_ATTRIBUTE_FIELD_NAME +"'.");
+            }
+
+            ///////////////////////////////////////
+            // Build the DescriptionType to test //
+            ///////////////////////////////////////
+
+            DescriptionType toTest = new DescriptionType();
+
+            //Build the title
+            List<LanguageStringType> titleList = new ArrayList<>();
+            LanguageStringType titleEN = new LanguageStringType();
+            titleEN.setValue("DescriptionType attribute title");
+            titleEN.setLang("en");
+            titleList.add(titleEN);
+            LanguageStringType titleFR = new LanguageStringType();
+            titleFR.setValue("Titre de l'attribut DescriptionType");
+            titleFR.setLang("fr");
+            titleList.add(titleFR);
+
+            toTest.setTitle(titleList);
+
+            //Build the resume
+            List<LanguageStringType> resumeList = new ArrayList<>();
+            LanguageStringType resumeEN = new LanguageStringType();
+            resumeEN.setValue("DescriptionType attribute resume");
+            resumeEN.setLang("en");
+            resumeList.add(resumeEN);
+            LanguageStringType resumeFR = new LanguageStringType();
+            resumeFR.setValue("Description de l'attribut DescriptionType");
+            resumeFR.setLang("fr");
+            resumeList.add(resumeFR);
+
+            toTest.setAbstract(resumeList);
+
+            //Build the keywords
+            List<KeywordsType> keywordsTypeList = new ArrayList<>();
+
+            KeywordsType descriptionTypeKeyword = new KeywordsType();
+            List<LanguageStringType> descriptionTypeList = new ArrayList<>();
+            LanguageStringType descriptionTypeEN = new LanguageStringType();
+            descriptionTypeEN.setValue("DescriptionType en");
+            descriptionTypeEN.setLang("en");
+            descriptionTypeList.add(descriptionTypeEN);
+            LanguageStringType descriptionTypeFR = new LanguageStringType();
+            descriptionTypeFR.setValue("DescriptionType fr");
+            descriptionTypeFR.setLang("fr");
+            descriptionTypeList.add(descriptionTypeFR);
+            descriptionTypeKeyword.setKeyword(descriptionTypeList);
+            keywordsTypeList.add(descriptionTypeKeyword);
+
+            KeywordsType attributeKeyword = new KeywordsType();
+            List<LanguageStringType> attributeList = new ArrayList<>();
+            LanguageStringType attributeEN = new LanguageStringType();
+            attributeEN.setValue("Attribute en");
+            attributeEN.setLang("en");
+            attributeList.add(attributeEN);
+            LanguageStringType attributeFR = new LanguageStringType();
+            attributeFR.setValue("Attribute fr");
+            attributeFR.setLang("fr");
+            attributeList.add(attributeFR);
+            attributeKeyword.setKeyword(attributeList);
+            keywordsTypeList.add(attributeKeyword);
+
+            toTest.setKeywords(keywordsTypeList);
+
+            //Build the identifier
+            CodeType identifier = new CodeType();
+            identifier.setValue("test:descriptionTypeAttribute");
+
+            toTest.setIdentifier(identifier);
+
+            //Build the metadata
+            List<JAXBElement<? extends MetadataType>> metadataList = new ArrayList<>();
+            QName qname = new QName("http://orbisgis.org", "metadata");
+            MetadataType metadata1 = new MetadataType();
+            metadata1.setTitle("metadata1");
+            metadata1.setHref("href1");
+            metadata1.setRole("role1");
+            metadata1.setTYPE(TypeType.SIMPLE);
+            metadataList.add(new JAXBElement<>(qname, MetadataType.class, metadata1));
+            MetadataType metadata2 = new MetadataType();
+            metadata2.setTitle("metadata2");
+            metadata2.setHref("href2");
+            metadata2.setRole("role2");
+            metadata2.setTYPE(TypeType.SIMPLE);
+            metadataList.add(new JAXBElement<>(qname, MetadataType.class, metadata2));
+
+            toTest.setMetadata(metadataList);
+
+            ///////////////////////////////
+            // Tests the DescriptionType //
+            ///////////////////////////////
+
+            //Test the title
+            String messageTitleNumber = "Number of titles is not the one expected ("+descriptionType.getTitle().size()+
+                    " instead of "+toTest.getTitle().size();
+            boolean sameSizeTitle = descriptionType.getTitle().size() != toTest.getTitle().size();
+            Assert.assertFalse(messageTitleNumber, sameSizeTitle);
+
+            boolean areAllTitlePresent = true;
+            for(LanguageStringType title1 : toTest.getTitle()){
+                boolean isTitlePresent = false;
+                for(LanguageStringType title2 : descriptionType.getTitle()){
+                    if(title1.getLang().equals(title2.getLang()) && title1.getValue().equals(title2.getValue())){
+                        isTitlePresent = true;
+                    }
+                }
+                if(!isTitlePresent){
+                    areAllTitlePresent = false;
+                }
+            }
+            String messageTitleElements = "The title list doesn't contain the same elements.";
+            Assert.assertTrue(messageTitleElements, areAllTitlePresent);
+
+            //Test the resume
+            String messageResumeNumber = "Number of resumes is not the one expected ("+
+                    descriptionType.getAbstract().size()+ " instead of "+toTest.getAbstract().size();
+            boolean sameSizeResume = descriptionType.getAbstract().size() == toTest.getAbstract().size();
+            Assert.assertTrue(messageResumeNumber, sameSizeResume);
+
+            boolean areAllResumePresent = true;
+            for(LanguageStringType resume1 : toTest.getAbstract()){
+                boolean isResumePresent = false;
+                for(LanguageStringType resume2 : descriptionType.getAbstract()){
+                    if(resume1.getLang().equals(resume2.getLang()) && resume1.getValue().equals(resume2.getValue())){
+                        isResumePresent = true;
+                    }
+                }
+                if(!isResumePresent){
+                    areAllResumePresent = false;
+                }
+            }
+            String messageElements = "The abstract list doesn't contain the same elements.";
+            Assert.assertTrue(messageElements, areAllResumePresent);
+
+            //test the keywords
+            String messageKeywordsNumber = "Number of keywords is not the one expected ("+
+                    descriptionType.getKeywords().size()+ " instead of "+toTest.getKeywords().size();
+            boolean sameSizeKeywords = descriptionType.getKeywords().size() == toTest.getKeywords().size();
+            Assert.assertTrue(messageKeywordsNumber, sameSizeKeywords);
+
+            boolean condition = true;
+            for(KeywordsType keyword1 : descriptionType.getKeywords()){
+                boolean sameKeywords = false;
+                for(KeywordsType keyword2 : toTest.getKeywords()){
+                    boolean validTranslation = (keyword1.getKeyword().size() == keyword2.getKeyword().size());
+                    for(LanguageStringType language1 : keyword1.getKeyword()){
+                        boolean sameTranslation = false;
+                        for(LanguageStringType language2 : keyword2.getKeyword()){
+                            if(language1.getLang().equals(language2.getLang()) &&
+                                    language1.getValue().equals(language2.getValue())){
+                                sameTranslation = true;
+                            }
+                        }
+                        validTranslation &= sameTranslation;
+                    }
+                    if(validTranslation){
+                        sameKeywords = true;
+                    }
+                }
+                condition &= sameKeywords;
+            }
+            String messageKeywordsElement = "The keyword list doesn't contain the same elements.";
+            Assert.assertTrue(messageKeywordsElement, condition);
+
+            //test the identifier
+            boolean identifierCondition = descriptionType.getIdentifier().getValue().equals(toTest.getIdentifier().getValue());
+            String messageIdentifier = "The identifier is not the one expected ("+descriptionType.getIdentifier().getValue()+
+                    " instead of "+toTest.getIdentifier().getValue()+").";
+            Assert.assertTrue(messageIdentifier, identifierCondition);
+
+            //Test the metadata
+            String messageMetadataNumber = "Number of metadata is not the one expected ("+
+                    descriptionType.getMetadata().size()+ " instead of "+toTest.getMetadata().size();
+            boolean sameSizeMetadata = descriptionType.getMetadata().size() == toTest.getMetadata().size();
+            Assert.assertTrue(messageMetadataNumber, sameSizeMetadata);
+
+            boolean areAllMetadataPresent = true;
+            for(JAXBElement element1 : toTest.getMetadata()){
+                MetadataType meta1 = (MetadataType)element1.getValue();
+                boolean isMetadataPresent = false;
+                for(JAXBElement element2 : descriptionType.getMetadata()){
+                    MetadataType meta2 = (MetadataType)element2.getValue();
+                    if(meta1.getHref().equals(meta2.getHref()) &&
+                            meta1.getRole().equals(meta2.getRole()) &&
+                            meta1.getTitle().equals(meta2.getTitle()) &&
+                            meta1.getTYPE().equals(meta2.getTYPE())){
+                        isMetadataPresent = true;
+                    }
+                }
+                if(!isMetadataPresent){
+                    areAllMetadataPresent = false;
+                }
+            }
+            String messageMetadata = "The metadata list doesn't contain the same elements.";
+            Assert.assertTrue(messageMetadata, areAllMetadataPresent);
+
+        } catch (NoSuchFieldException e) {
+            Assert.fail("Unable to get the field '"+ FULL_DESCRIPTION_TYPE_ATTRIBUTE_FIELD_NAME +"' from the class '" +
+                    this.getClass().getCanonicalName()+"'.");
+        }
+
+    }
+
+    /***************************
+     * SIMPLE DESCRIPTION TYPE *
+     ***************************/
+
+    /** Field containing the simple DescriptionTypeAttribute annotation. */
+    @DescriptionTypeAttribute(
+            title = "DescriptionType attribute title",
+            resume = "DescriptionType attribute resume",
+            keywords = {"DescriptionType","Attribute"}
+    )
+    public Object simpleDescriptionTypeAttribute;
+    /** Name of the field containing the simpleDescriptionTypeAttribute annotation. */
+    private static final String SIMPLE_DESCRIPTION_TYPE_ATTRIBUTE_FIELD_NAME = "simpleDescriptionTypeAttribute";
+
+    /**
+     * Test if the decoding and convert of the simple DescriptionTypeAttribute annotation into its java object is valid.
+     */
+    @Test
+    public void testSimpleDescriptionTypeAttributeConvert(){
+        try {
+            boolean annotationFound = false;
+            //Retrieve the DescriptionType object
+            DescriptionType descriptionType = new DescriptionType();
+            //Inspect all the annotation of the field to get the DescriptionTypeAttribute one
+            Field descriptionTypeField = this.getClass().getDeclaredField(SIMPLE_DESCRIPTION_TYPE_ATTRIBUTE_FIELD_NAME);
+            for(Annotation annotation : descriptionTypeField.getDeclaredAnnotations()){
+                //Once the annotation is get, decode it.
+                if(annotation instanceof DescriptionTypeAttribute){
+                    annotationFound = true;
+                    DescriptionTypeAttribute descriptionTypeAnnotation = (DescriptionTypeAttribute) annotation;
+                    ObjectAnnotationConverter.annotationToObject(descriptionTypeAnnotation, descriptionType);
+                }
+            }
+
+            //If the annotation hasn't been found, the test has failed.
+            if(!annotationFound){
+                Assert.fail("Unable to get the annotation '@DescriptionTypeAttribute' from the field '" +
+                        SIMPLE_DESCRIPTION_TYPE_ATTRIBUTE_FIELD_NAME +"'.");
+            }
+
+            ///////////////////////////////////////
+            // Build the DescriptionType to test //
+            ///////////////////////////////////////
+
+            DescriptionType toTest = new DescriptionType();
+
+            //Build the title
+            List<LanguageStringType> titleList = new ArrayList<>();
+            LanguageStringType title = new LanguageStringType();
+            title.setValue("DescriptionType attribute title");
+            titleList.add(title);
+
+            toTest.setTitle(titleList);
+
+            //Build the resume
+            List<LanguageStringType> resumeList = new ArrayList<>();
+            LanguageStringType resume = new LanguageStringType();
+            resume.setValue("DescriptionType attribute resume");
+            resumeList.add(resume);
+
+            toTest.setAbstract(resumeList);
+
+            //Build the keywords
+            List<KeywordsType> keywordsTypeList = new ArrayList<>();
+
+            KeywordsType descriptionTypeKeyword = new KeywordsType();
+            List<LanguageStringType> descriptionTypeList = new ArrayList<>();
+            LanguageStringType descriptionTypeKeyword1 = new LanguageStringType();
+            descriptionTypeKeyword1.setValue("DescriptionType");
+            descriptionTypeList.add(descriptionTypeKeyword1);
+            descriptionTypeKeyword.setKeyword(descriptionTypeList);
+            keywordsTypeList.add(descriptionTypeKeyword);
+
+            descriptionTypeKeyword = new KeywordsType();
+            descriptionTypeList = new ArrayList<>();
+            LanguageStringType descriptionTypeKeyword2 = new LanguageStringType();
+            descriptionTypeKeyword2.setValue("Attribute");
+            descriptionTypeList.add(descriptionTypeKeyword2);
+            descriptionTypeKeyword.setKeyword(descriptionTypeList);
+            keywordsTypeList.add(descriptionTypeKeyword);
+
+            toTest.setKeywords(keywordsTypeList);
+
+            //Build the identifier
+            toTest.setIdentifier(null);
+
+            //Build the metadata
+            toTest.setMetadata(null);
+
+            ///////////////////////////////
+            // Tests the DescriptionType //
+            ///////////////////////////////
+
+            //Test the title
+            String messageTitleNumber = "Number of titles is not the one expected ("+descriptionType.getTitle().size()+
+                    " instead of "+toTest.getTitle().size();
+            boolean sameSizeTitle = descriptionType.getTitle().size() != toTest.getTitle().size();
+            Assert.assertFalse(messageTitleNumber, sameSizeTitle);
+
+            boolean areAllTitlePresent = true;
+            for(LanguageStringType title1 : toTest.getTitle()){
+                boolean isTitlePresent = false;
+                for(LanguageStringType title2 : descriptionType.getTitle()){
+                    if(title1.getLang() == null && title2.getLang() == null &&
+                            title1.getValue().equals(title2.getValue())){
+                        isTitlePresent = true;
+                    }
+                }
+                if(!isTitlePresent){
+                    areAllTitlePresent = false;
+                }
+            }
+            String messageTitleElements = "The title list doesn't contain the same elements.";
+            Assert.assertTrue(messageTitleElements, areAllTitlePresent);
+
+            //Test the resume
+            String messageResumeNumber = "Number of resumes is not the one expected ("+
+                    descriptionType.getAbstract().size()+ " instead of "+toTest.getAbstract().size();
+            boolean sameSizeResume = descriptionType.getAbstract().size() == toTest.getAbstract().size();
+            Assert.assertTrue(messageResumeNumber, sameSizeResume);
+
+            boolean areAllResumePresent = true;
+            for(LanguageStringType resume1 : toTest.getAbstract()){
+                boolean isResumePresent = false;
+                for(LanguageStringType resume2 : descriptionType.getAbstract()){
+                    if(resume1.getLang() == null && resume2.getLang() == null &&
+                            resume1.getValue().equals(resume2.getValue())){
+                        isResumePresent = true;
+                    }
+                }
+                if(!isResumePresent){
+                    areAllResumePresent = false;
+                }
+            }
+            String messageElements = "The abstract list doesn't contain the same elements.";
+            Assert.assertTrue(messageElements, areAllResumePresent);
+
+            //test the keywords
+            String messageKeywordsNumber = "Number of keywords is not the one expected ("+
+                    descriptionType.getKeywords().size()+ " instead of "+toTest.getKeywords().size()+").";
+            boolean sameSizeKeywords = descriptionType.getKeywords().size() == toTest.getKeywords().size();
+            Assert.assertTrue(messageKeywordsNumber, sameSizeKeywords);
+
+            boolean condition = true;
+            for(KeywordsType keyword1 : descriptionType.getKeywords()){
+                boolean sameKeywords = false;
+                for(KeywordsType keyword2 : toTest.getKeywords()){
+                    boolean validTranslation = (keyword1.getKeyword().size() == keyword2.getKeyword().size());
+                    for(LanguageStringType language1 : keyword1.getKeyword()){
+                        boolean sameTranslation = false;
+                        for(LanguageStringType language2 : keyword2.getKeyword()){
+                            if(language1.getLang() == null && language2.getLang() == null &&
+                                    language1.getValue().equals(language2.getValue())){
+                                sameTranslation = true;
+                            }
+                        }
+                        validTranslation &= sameTranslation;
+                    }
+                    if(validTranslation){
+                        sameKeywords = true;
+                    }
+                }
+                condition &= sameKeywords;
+            }
+            String messageKeywordsElement = "The keyword list doesn't contain the same elements.";
+            Assert.assertTrue(messageKeywordsElement, condition);
+
+            //test the identifier
+            boolean identifierCondition = descriptionType.getIdentifier() == null;
+            String messageIdentifier = "The identifier is not the one expected ("+descriptionType.getIdentifier()+
+                    " instead of "+toTest.getIdentifier()+").";
+            Assert.assertTrue(messageIdentifier, identifierCondition);
+
+            //Test the metadata
+            String messageMetadataNumber = "Number of metadata is not the one expected ("+
+                    descriptionType.getMetadata().size()+ " instead of "+toTest.getMetadata().size();
+            boolean sameSizeMetadata = descriptionType.getMetadata().size() == toTest.getMetadata().size();
+            Assert.assertTrue(messageMetadataNumber, sameSizeMetadata);
+
+            boolean areAllMetadataPresent = true;
+            for(JAXBElement element1 : toTest.getMetadata()){
+                MetadataType meta1 = (MetadataType)element1.getValue();
+                boolean isMetadataPresent = false;
+                for(JAXBElement element2 : descriptionType.getMetadata()){
+                    MetadataType meta2 = (MetadataType)element2.getValue();
+                    if(meta1.getHref().equals(meta2.getHref()) &&
+                            meta1.getRole().equals(meta2.getRole()) &&
+                            meta1.getTitle().equals(meta2.getTitle()) &&
+                            meta1.getTYPE().equals(meta2.getTYPE())){
+                        isMetadataPresent = true;
+                    }
+                }
+                if(!isMetadataPresent){
+                    areAllMetadataPresent = false;
+                }
+            }
+            String messageMetadata = "The metadata list doesn't contain the same elements.";
+            Assert.assertTrue(messageMetadata, areAllMetadataPresent);
+
+        } catch (NoSuchFieldException e) {
+            Assert.fail("Unable to get the field '"+ SIMPLE_DESCRIPTION_TYPE_ATTRIBUTE_FIELD_NAME +"' from the class '" +
+                    this.getClass().getCanonicalName()+"'.");
+        }
+
+    }
+
+
+    /*************************
+     * MINI DESCRIPTION TYPE *
+     *************************/
+
+    /** Field containing the minimal DescriptionTypeAttribute annotation. */
+    @DescriptionTypeAttribute(
+            title = "DescriptionType attribute title"
+    )
+    public Object miniDescriptionTypeAttribute;
+    /** Name of the field containing the miniDescriptionTypeAttribute annotation. */
+    private static final String  MINI_DESCRIPTION_TYPE_ATTRIBUTE_FIELD_NAME = "miniDescriptionTypeAttribute";
+
+    /**
+     * Test if the decoding and convert of the minimal DescriptionTypeAttribute annotation into its java object is valid.
+     */
+    @Test
+    public void testMinimalDescriptionTypeAttributeConvert(){
+        try {
+            boolean annotationFound = false;
+            //Retrieve the DescriptionType object
+            DescriptionType descriptionType = new DescriptionType();
+            //Inspect all the annotation of the field to get the DescriptionTypeAttribute one
+            Field descriptionTypeField = this.getClass().getDeclaredField(MINI_DESCRIPTION_TYPE_ATTRIBUTE_FIELD_NAME);
+            for(Annotation annotation : descriptionTypeField.getDeclaredAnnotations()){
+                //Once the annotation is get, decode it.
+                if(annotation instanceof DescriptionTypeAttribute){
+                    annotationFound = true;
+                    DescriptionTypeAttribute descriptionTypeAnnotation = (DescriptionTypeAttribute) annotation;
+                    ObjectAnnotationConverter.annotationToObject(descriptionTypeAnnotation, descriptionType);
+                }
+            }
+
+            //If the annotation hasn't been found, the test has failed.
+            if(!annotationFound){
+                Assert.fail("Unable to get the annotation '@DescriptionTypeAttribute' from the field '" +
+                        SIMPLE_DESCRIPTION_TYPE_ATTRIBUTE_FIELD_NAME +"'.");
+            }
+
+            ///////////////////////////////////////
+            // Build the DescriptionType to test //
+            ///////////////////////////////////////
+
+            DescriptionType toTest = new DescriptionType();
+
+            //Build the title
+            List<LanguageStringType> titleList = new ArrayList<>();
+            LanguageStringType title = new LanguageStringType();
+            title.setValue("DescriptionType attribute title");
+            titleList.add(title);
+
+            toTest.setTitle(titleList);
+
+            //Build the resume
+            toTest.setAbstract(null);
+
+            //Build the keywords
+            toTest.setKeywords(null);
+
+            //Build the identifier
+            toTest.setIdentifier(null);
+
+            //Build the metadata
+            toTest.setMetadata(null);
+
+            ///////////////////////////////
+            // Tests the DescriptionType //
+            ///////////////////////////////
+
+            //Test the title
+            String messageTitleNumber = "Number of titles is not the one expected ("+descriptionType.getTitle().size()+
+                    " instead of "+toTest.getTitle().size();
+            boolean sameSizeTitle = descriptionType.getTitle().size() != toTest.getTitle().size();
+            Assert.assertFalse(messageTitleNumber, sameSizeTitle);
+
+            boolean areAllTitlePresent = true;
+            for(LanguageStringType title1 : toTest.getTitle()){
+                boolean isTitlePresent = false;
+                for(LanguageStringType title2 : descriptionType.getTitle()){
+                    if(title1.getLang() == null && title2.getLang() == null &&
+                            title1.getValue().equals(title2.getValue())){
+                        isTitlePresent = true;
+                    }
+                }
+                if(!isTitlePresent){
+                    areAllTitlePresent = false;
+                }
+            }
+            String messageTitleElements = "The title list doesn't contain the same elements.";
+            Assert.assertTrue(messageTitleElements, areAllTitlePresent);
+
+            //Test the resume
+            String messageResumeNumber = "Number of resumes is not the one expected ("+
+                    descriptionType.getAbstract().size()+ " instead of "+toTest.getAbstract().size();
+            boolean sameSizeResume = descriptionType.getAbstract().size() == toTest.getAbstract().size();
+            Assert.assertTrue(messageResumeNumber, sameSizeResume);
+
+            boolean areAllResumePresent = true;
+            for(LanguageStringType resume1 : toTest.getAbstract()){
+                boolean isResumePresent = false;
+                for(LanguageStringType resume2 : descriptionType.getAbstract()){
+                    if(resume1.getLang() == null && resume2.getLang() == null &&
+                            resume1.getValue().equals(resume2.getValue())){
+                        isResumePresent = true;
+                    }
+                }
+                if(!isResumePresent){
+                    areAllResumePresent = false;
+                }
+            }
+            String messageElements = "The abstract list doesn't contain the same elements.";
+            Assert.assertTrue(messageElements, areAllResumePresent);
+
+            //test the keywords
+            String messageKeywordsNumber = "Number of keywords is not the one expected ("+
+                    descriptionType.getKeywords().size()+ " instead of "+toTest.getKeywords().size()+").";
+            boolean sameSizeKeywords = descriptionType.getKeywords().size() == toTest.getKeywords().size();
+            Assert.assertTrue(messageKeywordsNumber, sameSizeKeywords);
+
+            boolean condition = true;
+            for(KeywordsType keyword1 : descriptionType.getKeywords()){
+                boolean sameKeywords = false;
+                for(KeywordsType keyword2 : toTest.getKeywords()){
+                    boolean validTranslation = (keyword1.getKeyword().size() == keyword2.getKeyword().size());
+                    for(LanguageStringType language1 : keyword1.getKeyword()){
+                        boolean sameTranslation = false;
+                        for(LanguageStringType language2 : keyword2.getKeyword()){
+                            if(language1.getLang() == null && language2.getLang() == null &&
+                                    language1.getValue().equals(language2.getValue())){
+                                sameTranslation = true;
+                            }
+                        }
+                        validTranslation &= sameTranslation;
+                    }
+                    if(validTranslation){
+                        sameKeywords = true;
+                    }
+                }
+                condition &= sameKeywords;
+            }
+            String messageKeywordsElement = "The keyword list doesn't contain the same elements.";
+            Assert.assertTrue(messageKeywordsElement, condition);
+
+            //test the identifier
+            boolean identifierCondition = descriptionType.getIdentifier() == null;
+            String messageIdentifier = "The identifier is not the one expected ("+descriptionType.getIdentifier()+
+                    " instead of "+toTest.getIdentifier()+").";
+            Assert.assertTrue(messageIdentifier, identifierCondition);
+
+            //Test the metadata
+            String messageMetadataNumber = "Number of metadata is not the one expected ("+
+                    descriptionType.getMetadata().size()+ " instead of "+toTest.getMetadata().size();
+            boolean sameSizeMetadata = descriptionType.getMetadata().size() == toTest.getMetadata().size();
+            Assert.assertTrue(messageMetadataNumber, sameSizeMetadata);
+
+            boolean areAllMetadataPresent = true;
+            for(JAXBElement element1 : toTest.getMetadata()){
+                MetadataType meta1 = (MetadataType)element1.getValue();
+                boolean isMetadataPresent = false;
+                for(JAXBElement element2 : descriptionType.getMetadata()){
+                    MetadataType meta2 = (MetadataType)element2.getValue();
+                    if(meta1.getHref().equals(meta2.getHref()) &&
+                            meta1.getRole().equals(meta2.getRole()) &&
+                            meta1.getTitle().equals(meta2.getTitle()) &&
+                            meta1.getTYPE().equals(meta2.getTYPE())){
+                        isMetadataPresent = true;
+                    }
+                }
+                if(!isMetadataPresent){
+                    areAllMetadataPresent = false;
+                }
+            }
+            String messageMetadata = "The metadata list doesn't contain the same elements.";
+            Assert.assertTrue(messageMetadata, areAllMetadataPresent);
+
+        } catch (NoSuchFieldException e) {
+            Assert.fail("Unable to get the field '"+ MINI_DESCRIPTION_TYPE_ATTRIBUTE_FIELD_NAME +"' from the class '" +
+                    this.getClass().getCanonicalName()+"'.");
+        }
+
+    }
+}

--- a/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/controller/utils/FormatConvertTest.java
+++ b/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/controller/utils/FormatConvertTest.java
@@ -1,0 +1,202 @@
+package org.orbisgis.wpsservice.controller.utils;
+
+import net.opengis.wps.v_2_0.Format;
+import org.junit.Assert;
+import org.junit.Test;
+import org.orbisgis.wpsgroovyapi.attributes.FormatAttribute;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.math.BigInteger;
+
+/**
+ * This test class perform three test on the Format annotation parsing.
+ * The test are done on converting a @FormatAttribute annotation into the model java object.
+ * Each test are done on different annotation complexity : a full annotation and a simple one.
+ *
+ * @author Sylvain PALOMINOS
+ */
+public class FormatConvertTest {
+
+
+    /***************
+     * FULL FORMAT *
+     ***************/
+
+    @FormatAttribute(
+            mimeType = "mimetype",
+            encoding = "simple",
+            schema = "schema",
+            maximumMegaBytes = 1,
+            isDefaultFormat = true
+    )
+    public Object fullFormatAttribute;
+    private final static String FULL_FORMAT_ATTRIBUTE_FIELD_NAME = "fullFormatAttribute";
+
+    @Test
+    public void testFullFormatAttributeConvert(){
+        try {
+            boolean annotationFound = false;
+            //Retrieve the DescriptionType object
+            Format format = new Format();
+            //Inspect all the annotation of the field to get the DescriptionTypeAttribute one
+            Field formatField = this.getClass().getDeclaredField(FULL_FORMAT_ATTRIBUTE_FIELD_NAME);
+            for(Annotation annotation : formatField.getDeclaredAnnotations()){
+                //Once the annotation is get, decode it.
+                if(annotation instanceof FormatAttribute){
+                    annotationFound = true;
+                    FormatAttribute formatAnnotation = (FormatAttribute) annotation;
+                    format = ObjectAnnotationConverter.annotationToObject(formatAnnotation);
+                }
+            }
+
+            //If the annotation hasn't been found, the test has failed.
+            if(!annotationFound){
+                Assert.fail("Unable to get the annotation '@FormatAttribute' from the field '" +
+                        FULL_FORMAT_ATTRIBUTE_FIELD_NAME +"'.");
+            }
+
+            //////////////////////////////
+            // Build the Format to test //
+            //////////////////////////////
+
+            Format toTest = new Format();
+
+            toTest.setDefault(true);
+            toTest.setEncoding("simple");
+            toTest.setMaximumMegabytes(BigInteger.valueOf(1));
+            toTest.setMimeType("mimetype");
+            toTest.setSchema("schema");
+
+
+            //////////////////////
+            // Tests the Format //
+            //////////////////////
+
+            //test the default
+            String messageDefault = "The default state is not the one expected ("+
+                    format.isDefault()+ " instead of "+toTest.isDefault();
+            boolean conditionDefault = format.isDefault() == toTest.isDefault();
+            Assert.assertTrue(messageDefault, conditionDefault);
+
+            //test the encoding
+            String messageEncoding = "The encoding is not the one expected ("+
+                    format.getEncoding()+ " instead of "+toTest.getEncoding();
+            boolean conditionEncoding = format.getEncoding().equals(toTest.getEncoding());
+            Assert.assertTrue(messageEncoding, conditionEncoding);
+
+            //test the maximum megabyte
+            String messageMaximumMegabytes = "The maximum megabyte value is not the one expected ("+
+                    format.getMaximumMegabytes()+ " instead of "+toTest.getMaximumMegabytes();
+            boolean conditionMaximumMegabytes = format.getMaximumMegabytes().equals(toTest.getMaximumMegabytes());
+            Assert.assertTrue(messageMaximumMegabytes, conditionMaximumMegabytes);
+
+            //test the encoding
+            String messageMimeType = "The encoding is not the one expected ("+
+                    format.getMimeType()+ " instead of "+toTest.getMimeType();
+            boolean conditionMimeType = format.getMimeType().equals(toTest.getMimeType());
+            Assert.assertTrue(messageMimeType, conditionMimeType);
+
+            //test the schema
+            String messageSchema = "The schema value is not the one expected ("+
+                    format.getSchema()+ " instead of "+toTest.getSchema();
+            boolean conditionSchema = format.getSchema().equals(toTest.getSchema());
+            Assert.assertTrue(messageSchema, conditionSchema);
+
+
+        } catch (NoSuchFieldException e) {
+            Assert.fail("Unable to get the field '"+ FULL_FORMAT_ATTRIBUTE_FIELD_NAME +"' from the class '" +
+                    this.getClass().getCanonicalName()+"'.");
+        }
+    }
+
+
+    /*****************
+     * SIMPLE FORMAT *
+     *****************/
+
+    @FormatAttribute(
+            mimeType = "mimetype",
+            schema = "schema"
+    )
+    public Object simpleFormatAttribute;
+    private final static String SIMPLE_FORMAT_ATTRIBUTE_FIELD_NAME = "simpleFormatAttribute";
+
+    @Test
+    public void testSimpleFormatAttributeConvert(){
+        try {
+            boolean annotationFound = false;
+            //Retrieve the DescriptionType object
+            Format format = new Format();
+            //Inspect all the annotation of the field to get the DescriptionTypeAttribute one
+            Field formatField = this.getClass().getDeclaredField(SIMPLE_FORMAT_ATTRIBUTE_FIELD_NAME);
+            for(Annotation annotation : formatField.getDeclaredAnnotations()){
+                //Once the annotation is get, decode it.
+                if(annotation instanceof FormatAttribute){
+                    annotationFound = true;
+                    FormatAttribute formatAnnotation = (FormatAttribute) annotation;
+                    format = ObjectAnnotationConverter.annotationToObject(formatAnnotation);
+                }
+            }
+
+            //If the annotation hasn't been found, the test has failed.
+            if(!annotationFound){
+                Assert.fail("Unable to get the annotation '@FormatAttribute' from the field '" +
+                        FULL_FORMAT_ATTRIBUTE_FIELD_NAME +"'.");
+            }
+
+            //////////////////////////////
+            // Build the Format to test //
+            //////////////////////////////
+
+            Format toTest = new Format();
+
+            toTest.setMimeType("mimetype");
+            toTest.setSchema("schema");
+
+            toTest.setDefault(false);
+            toTest.setEncoding("simple");
+            toTest.setMaximumMegabytes(null);
+
+
+            //////////////////////
+            // Tests the Format //
+            //////////////////////
+
+            //test the default
+            String messageDefault = "The default state is not the one expected ("+
+                    format.isDefault()+ " instead of "+toTest.isDefault();
+            boolean conditionDefault = format.isDefault() == toTest.isDefault();
+            Assert.assertTrue(messageDefault, conditionDefault);
+
+            //test the encoding
+            String messageEncoding = "The encoding is not the one expected ("+
+                    format.getEncoding()+ " instead of "+toTest.getEncoding();
+            boolean conditionEncoding = format.getEncoding().equals(toTest.getEncoding());
+            Assert.assertTrue(messageEncoding, conditionEncoding);
+
+            //test the maximum megabyte
+            String messageMaximumMegabytes = "The maximum megabyte value is not the one expected ("+
+                    format.getMaximumMegabytes()+ " instead of "+toTest.getMaximumMegabytes();
+            boolean conditionMaximumMegabytes = format.getMaximumMegabytes() == toTest.getMaximumMegabytes();
+            Assert.assertTrue(messageMaximumMegabytes, conditionMaximumMegabytes);
+
+            //test the encoding
+            String messageMimeType = "The encoding is not the one expected ("+
+                    format.getMimeType()+ " instead of "+toTest.getMimeType();
+            boolean conditionMimeType = format.getMimeType().equals(toTest.getMimeType());
+            Assert.assertTrue(messageMimeType, conditionMimeType);
+
+            //test the schema
+            String messageSchema = "The schema value is not the one expected ("+
+                    format.getSchema()+ " instead of "+toTest.getSchema();
+            boolean conditionSchema = format.getSchema().equals(toTest.getSchema());
+            Assert.assertTrue(messageSchema, conditionSchema);
+
+
+        } catch (NoSuchFieldException e) {
+            Assert.fail("Unable to get the field '"+ SIMPLE_FORMAT_ATTRIBUTE_FIELD_NAME +"' from the class '" +
+                    this.getClass().getCanonicalName()+"'.");
+        }
+    }
+}

--- a/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/controller/utils/FormatConvertTest.java
+++ b/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/controller/utils/FormatConvertTest.java
@@ -37,9 +37,9 @@ public class FormatConvertTest {
     public void testFullFormatAttributeConvert(){
         try {
             boolean annotationFound = false;
-            //Retrieve the DescriptionType object
+            //Retrieve the Format object
             Format format = new Format();
-            //Inspect all the annotation of the field to get the DescriptionTypeAttribute one
+            //Inspect all the annotation of the field to get the FormatAttribute one
             Field formatField = this.getClass().getDeclaredField(FULL_FORMAT_ATTRIBUTE_FIELD_NAME);
             for(Annotation annotation : formatField.getDeclaredAnnotations()){
                 //Once the annotation is get, decode it.
@@ -126,9 +126,9 @@ public class FormatConvertTest {
     public void testSimpleFormatAttributeConvert(){
         try {
             boolean annotationFound = false;
-            //Retrieve the DescriptionType object
+            //Retrieve the Format object
             Format format = new Format();
-            //Inspect all the annotation of the field to get the DescriptionTypeAttribute one
+            //Inspect all the annotation of the field to get the FormatAttribute one
             Field formatField = this.getClass().getDeclaredField(SIMPLE_FORMAT_ATTRIBUTE_FIELD_NAME);
             for(Annotation annotation : formatField.getDeclaredAnnotations()){
                 //Once the annotation is get, decode it.

--- a/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/controller/utils/MetadataConvertTest.java
+++ b/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/controller/utils/MetadataConvertTest.java
@@ -1,0 +1,191 @@
+package org.orbisgis.wpsservice.controller.utils;
+
+import net.opengis.ows.v_2_0.MetadataType;
+import org.hisrc.w3c.xlink.v_1_0.TypeType;
+import org.junit.Assert;
+import org.junit.Test;
+import org.orbisgis.wpsgroovyapi.attributes.MetadataAttribute;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+
+/**
+ * @author Sylvain PALOMINOS
+ */
+public class MetadataConvertTest {
+
+    /*****************
+     * FULL METADATA *
+     *****************/
+
+    /** Field containing the full MetadataAttribute annotation. */
+    @MetadataAttribute(
+            title = "title",
+            href = "href",
+            linkType = "simple",
+            role = "role"
+    )
+    public Object fullMetadataAttribute;
+    /** Name of the field containing the fullMetadataAttribute annotation. */
+    private static final String FULL_METADATA_ATTRIBUTE_FIELD_NAME = "fullMetadataAttribute";
+
+    /**
+     * Test if the decoding and convert of the full MetadataAttribute annotation into its java object is valid.
+     */
+    @Test
+    public void testFullMetadataAttributeConvert() {
+        try {
+            boolean annotationFound = false;
+            //Retrieve the Metadata object
+            MetadataType metadata = new MetadataType();
+            //Inspect all the annotation of the field to get the MetadataAttribute one
+            Field metadataField = this.getClass().getDeclaredField(FULL_METADATA_ATTRIBUTE_FIELD_NAME);
+            for (Annotation annotation : metadataField.getDeclaredAnnotations()) {
+                //Once the annotation is get, decode it.
+                if (annotation instanceof MetadataAttribute) {
+                    annotationFound = true;
+                    MetadataAttribute metadataAnnotation = (MetadataAttribute) annotation;
+                    metadata = ObjectAnnotationConverter.annotationToObject(metadataAnnotation);
+                }
+            }
+
+            //If the annotation hasn't been found, the test has failed.
+            if (!annotationFound) {
+                Assert.fail("Unable to get the annotation '@MetadataAnnotation' from the field '" +
+                        FULL_METADATA_ATTRIBUTE_FIELD_NAME + "'.");
+            }
+
+            ////////////////////////////////
+            // Build the Metadata to test //
+            ////////////////////////////////
+
+            MetadataType toTest = new MetadataType();
+
+            toTest.setHref("href");
+            toTest.setRole("role");
+            toTest.setTitle("title");
+            toTest.setTYPE(TypeType.SIMPLE);
+
+
+            ////////////////////////////////
+            // Build the Metadata to test //
+            ////////////////////////////////
+
+            //Test the href
+            String messageHref = "The href value is not the one expected (" +
+                    metadata.getHref() + " instead of " + toTest.getHref();
+            boolean conditionHref = metadata.getHref().equals(toTest.getHref());
+            Assert.assertTrue(messageHref, conditionHref);
+
+            //Test the role
+            String messageRole = "The role value is not the one expected (" +
+                    metadata.getRole() + " instead of " + toTest.getRole();
+            boolean conditionRole = metadata.getRole().equals(toTest.getRole());
+            Assert.assertTrue(messageRole, conditionRole);
+
+            //Test the title
+            String messageTitle = "The title value is not the one expected (" +
+                    metadata.getTitle() + " instead of " + toTest.getTitle();
+            boolean conditionTitle = metadata.getTitle().equals(toTest.getTitle());
+            Assert.assertTrue(messageTitle, conditionTitle);
+
+            //Test the TYPE
+            String messageTYPE = "The TYPE value is not the one expected (" +
+                    metadata.getTYPE() + " instead of " + toTest.getTYPE();
+            boolean conditionTYPE = metadata.getTYPE().equals(toTest.getTYPE());
+            Assert.assertTrue(messageTYPE, conditionTYPE);
+
+
+        } catch (NoSuchFieldException e) {
+            Assert.fail("Unable to get the field '" + FULL_METADATA_ATTRIBUTE_FIELD_NAME + "' from the class '" +
+                    this.getClass().getCanonicalName() + "'.");
+        }
+    }
+
+    /*******************
+     * SIMPLE METADATA *
+     *******************/
+
+    /** Field containing the simple MetadataTypeAttribute annotation. */
+    @MetadataAttribute(
+            title = "title",
+            href = "href",
+            role = "role"
+    )
+    public Object simpleMetadataAttribute;
+    /** Name of the field containing the simpleMetadataAttribute annotation. */
+    private static final String SIMPLE_METADATA_ATTRIBUTE_FIELD_NAME = "simpleMetadataAttribute";
+
+    /**
+     * Test if the decoding and convert of the simple MetadataAttribute annotation into its java object is valid.
+     */
+    @Test
+    public void testSimpleMetadataAttributeConvert() {
+        try {
+            boolean annotationFound = false;
+            //Retrieve the Metadata object
+            MetadataType metadata = new MetadataType();
+            //Inspect all the annotation of the field to get the MetadataAttribute one
+            Field metadataField = this.getClass().getDeclaredField(SIMPLE_METADATA_ATTRIBUTE_FIELD_NAME);
+            for (Annotation annotation : metadataField.getDeclaredAnnotations()) {
+                //Once the annotation is get, decode it.
+                if (annotation instanceof MetadataAttribute) {
+                    annotationFound = true;
+                    MetadataAttribute metadataAnnotation = (MetadataAttribute) annotation;
+                    metadata = ObjectAnnotationConverter.annotationToObject(metadataAnnotation);
+                }
+            }
+
+            //If the annotation hasn't been found, the test has failed.
+            if (!annotationFound) {
+                Assert.fail("Unable to get the annotation '@MetadataAnnotation' from the field '" +
+                        SIMPLE_METADATA_ATTRIBUTE_FIELD_NAME + "'.");
+            }
+
+            ////////////////////////////////
+            // Build the Metadata to test //
+            ////////////////////////////////
+
+            MetadataType toTest = new MetadataType();
+
+            toTest.setHref("href");
+            toTest.setRole("role");
+            toTest.setTitle("title");
+            toTest.setTYPE(TypeType.SIMPLE);
+
+
+            ////////////////////////////////
+            // Build the Metadata to test //
+            ////////////////////////////////
+
+            //Test the href
+            String messageHref = "The href value is not the one expected (" +
+                    metadata.getHref() + " instead of " + toTest.getHref();
+            boolean conditionHref = metadata.getHref().equals(toTest.getHref());
+            Assert.assertTrue(messageHref, conditionHref);
+
+            //Test the role
+            String messageRole = "The role value is not the one expected (" +
+                    metadata.getRole() + " instead of " + toTest.getRole();
+            boolean conditionRole = metadata.getRole().equals(toTest.getRole());
+            Assert.assertTrue(messageRole, conditionRole);
+
+            //Test the title
+            String messageTitle = "The title value is not the one expected (" +
+                    metadata.getTitle() + " instead of " + toTest.getTitle();
+            boolean conditionTitle = metadata.getTitle().equals(toTest.getTitle());
+            Assert.assertTrue(messageTitle, conditionTitle);
+
+            //Test the TYPE
+            String messageTYPE = "The TYPE value is not the one expected (" +
+                    metadata.getTYPE() + " instead of " + toTest.getTYPE();
+            boolean conditionTYPE = metadata.getTYPE().equals(toTest.getTYPE());
+            Assert.assertTrue(messageTYPE, conditionTYPE);
+
+
+        } catch (NoSuchFieldException e) {
+            Assert.fail("Unable to get the field '" + SIMPLE_METADATA_ATTRIBUTE_FIELD_NAME + "' from the class '" +
+                    this.getClass().getCanonicalName() + "'.");
+        }
+    }
+}

--- a/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/controller/utils/ValuesConvertTest.java
+++ b/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/controller/utils/ValuesConvertTest.java
@@ -15,11 +15,11 @@ import java.lang.reflect.Field;
 public class ValuesConvertTest {
 
 
-    /*********************
-     * FULL RANGE VALUES *
-     *********************/
+    /**************
+     * FULL RANGE *
+     **************/
 
-    /** Field containing the full Values annotation. */
+    /** Field containing the full annotation. */
     @ValuesAttribute(
             type = ValuesType.RANGE,
             maximum = "maximum",
@@ -27,21 +27,21 @@ public class ValuesConvertTest {
             spacing = "spacing",
             value = "value"
     )
-    public Object fullRangeValuesAttribute;
-    /** Name of the field containing the fullRangeValuesAttribute annotation. */
-    private static final String FULL_RANGE_VALUES_ATTRIBUTE_FIELD_NAME = "fullRangeValuesAttribute";
+    public Object fullRangeAttribute;
+    /** Name of the field containing the fullRangeAttribute annotation. */
+    private static final String FULL_RANGE_ATTRIBUTE_FIELD_NAME = "fullRangeAttribute";
 
     /**
-     * Test if the decoding and convert of the full range Values annotation into its java object is valid.
+     * Test if the decoding and convert of the full range annotation into its java object is valid.
      */
     @Test
-    public void testFullRangeValuesAttributeConvert() {
+    public void testFullRangeAttributeConvert() {
         try {
             boolean annotationFound = false;
             //Retrieve the Values object
             Object object = null;
             //Inspect all the annotation of the field to get the ValuesAttribute one
-            Field valuesField = this.getClass().getDeclaredField(FULL_RANGE_VALUES_ATTRIBUTE_FIELD_NAME);
+            Field valuesField = this.getClass().getDeclaredField(FULL_RANGE_ATTRIBUTE_FIELD_NAME);
             for (Annotation annotation : valuesField.getDeclaredAnnotations()) {
                 //Once the annotation is get, decode it.
                 if (annotation instanceof ValuesAttribute) {
@@ -54,7 +54,7 @@ public class ValuesConvertTest {
             //If the annotation hasn't been found, the test has failed.
             if (!annotationFound || object == null) {
                 Assert.fail("Unable to get the annotation '@ValuesAttribute' from the field '" +
-                        FULL_RANGE_VALUES_ATTRIBUTE_FIELD_NAME + "'.");
+                        FULL_RANGE_ATTRIBUTE_FIELD_NAME + "'.");
             }
             String messageClass = "The parsed value should be a '"+RangeType.class.getCanonicalName()+"' instance of '"+
                     object.getClass().getCanonicalName()+"'.";
@@ -104,35 +104,35 @@ public class ValuesConvertTest {
             Assert.assertTrue(messageSpacing, conditionSpacing);
 
         } catch (NoSuchFieldException e) {
-            Assert.fail("Unable to get the field '" + FULL_RANGE_VALUES_ATTRIBUTE_FIELD_NAME + "' from the class '" +
+            Assert.fail("Unable to get the field '" + FULL_RANGE_ATTRIBUTE_FIELD_NAME + "' from the class '" +
                     this.getClass().getCanonicalName() + "'.");
         }
     }
 
 
-    /************************
-     * MINIMAL RANGE VALUES *
-     ************************/
+    /*****************
+     * MINIMAL RANGE *
+     *****************/
 
-    /** Field containing the minimal Range Values annotation. */
+    /** Field containing the minimal Range annotation. */
     @ValuesAttribute(
             type = ValuesType.RANGE
     )
-    public Object minimalRangeValuesAttribute;
-    /** Name of the field containing the minimalRangeValuesAttribute annotation. */
-    private static final String MINIMAL_RANGE_VALUES_ATTRIBUTE_FIELD_NAME = "minimalRangeValuesAttribute";
+    public Object minimalRangeAttribute;
+    /** Name of the field containing the minimalRangeAttribute annotation. */
+    private static final String MINIMAL_RANGE_ATTRIBUTE_FIELD_NAME = "minimalRangeAttribute";
 
     /**
-     * Test if the decoding and convert of the minimal range Values annotation into its java object is valid.
+     * Test if the decoding and convert of the minimal range annotation into its java object is valid.
      */
     @Test
-    public void testMinimalRangeValuesAttributeConvert() {
+    public void testMinimalRangeAttributeConvert() {
         try {
             boolean annotationFound = false;
             //Retrieve the Values object
             Object object = null;
             //Inspect all the annotation of the field to get the ValuesAttribute one
-            Field valuesField = this.getClass().getDeclaredField(MINIMAL_RANGE_VALUES_ATTRIBUTE_FIELD_NAME);
+            Field valuesField = this.getClass().getDeclaredField(MINIMAL_RANGE_ATTRIBUTE_FIELD_NAME);
             for (Annotation annotation : valuesField.getDeclaredAnnotations()) {
                 //Once the annotation is get, decode it.
                 if (annotation instanceof ValuesAttribute) {
@@ -145,7 +145,7 @@ public class ValuesConvertTest {
             //If the annotation hasn't been found, the test has failed.
             if (!annotationFound || object == null) {
                 Assert.fail("Unable to get the annotation '@ValuesAttribute' from the field '" +
-                        MINIMAL_RANGE_VALUES_ATTRIBUTE_FIELD_NAME + "'.");
+                        MINIMAL_RANGE_ATTRIBUTE_FIELD_NAME + "'.");
             }
             String messageClass = "The parsed value should be a '"+RangeType.class.getCanonicalName()+"' instance of '"+
                     object.getClass().getCanonicalName()+"'.";
@@ -183,7 +183,130 @@ public class ValuesConvertTest {
             Assert.assertTrue(messageSpacing, conditionSpacing);
 
         } catch (NoSuchFieldException e) {
-            Assert.fail("Unable to get the field '" + MINIMAL_RANGE_VALUES_ATTRIBUTE_FIELD_NAME + "' from the class '" +
+            Assert.fail("Unable to get the field '" + MINIMAL_RANGE_ATTRIBUTE_FIELD_NAME + "' from the class '" +
+                    this.getClass().getCanonicalName() + "'.");
+        }
+    }
+
+
+    /***************
+     * FULL VALUES *
+     ***************/
+
+    /** Field containing the full Values annotation. */
+    @ValuesAttribute(
+            type = ValuesType.VALUE,
+            maximum = "maximum",
+            minimum = "minimum",
+            spacing = "spacing",
+            value = "value"
+    )
+    public Object fullValueAttribute;
+    /** Name of the field containing the fullValueAttribute annotation. */
+    private static final String FULL_VALUE_ATTRIBUTE_FIELD_NAME = "fullValueAttribute";
+
+    /**
+     * Test if the decoding and convert of the full value annotation into its java object is valid.
+     */
+    @Test
+    public void testFullRangeValuesAttributeConvert() {
+        try {
+            boolean annotationFound = false;
+            //Retrieve the Values object
+            Object object = null;
+            //Inspect all the annotation of the field to get the ValuesAttribute one
+            Field valuesField = this.getClass().getDeclaredField(FULL_VALUE_ATTRIBUTE_FIELD_NAME);
+            for (Annotation annotation : valuesField.getDeclaredAnnotations()) {
+                //Once the annotation is get, decode it.
+                if (annotation instanceof ValuesAttribute) {
+                    annotationFound = true;
+                    ValuesAttribute valuesAnnotation = (ValuesAttribute) annotation;
+                    object = ObjectAnnotationConverter.annotationToObject(valuesAnnotation);
+                }
+            }
+
+            //If the annotation hasn't been found, the test has failed.
+            if (!annotationFound || object == null) {
+                Assert.fail("Unable to get the annotation '@ValuesAttribute' from the field '" +
+                        FULL_VALUE_ATTRIBUTE_FIELD_NAME + "'.");
+            }
+            String messageClass = "The parsed value should be a '"+ValueType.class.getCanonicalName()+"' instance of '"+
+                    object.getClass().getCanonicalName()+"'.";
+            boolean conditionClass = object instanceof ValueType;
+            Assert.assertTrue(messageClass, conditionClass);
+
+            ValueType valueType = (ValueType) object;
+
+            ////////////////////////////////////
+            // Build the Range Values to test //
+            ////////////////////////////////////
+
+            ValueType toTest = new ValueType();
+            toTest.setValue("value");
+
+            ////////////////////////////
+            // Tests the Range Values //
+            ////////////////////////////
+
+            //Test the value
+            String messageValue = "The value is not the one expected (" +
+                    valueType.getValue() + " instead of " + toTest.getValue();
+            boolean conditionValue = valueType.getValue().equals(toTest.getValue());
+            Assert.assertTrue(messageValue, conditionValue);
+
+        } catch (NoSuchFieldException e) {
+            Assert.fail("Unable to get the field '" + FULL_VALUE_ATTRIBUTE_FIELD_NAME + "' from the class '" +
+                    this.getClass().getCanonicalName() + "'.");
+        }
+    }
+
+
+    /*****************
+     * MINIMAL VALUE *
+     *****************/
+
+    /** Field containing the minimal Value annotation. */
+    @ValuesAttribute(
+            type = ValuesType.VALUE
+    )
+    public Object minimalValueAttribute;
+    /** Name of the field containing the minimalValueAttribute annotation. */
+    private static final String MINIMAL_VALUE_ATTRIBUTE_FIELD_NAME = "minimalValueAttribute";
+
+    /**
+     * Test if the decoding and convert of the minimal value annotation into its java object is valid.
+     */
+    @Test
+    public void testMinimalValueAttributeConvert() {
+        try {
+            boolean annotationFound = false;
+            //Retrieve the Values object
+            Object object = null;
+            //Inspect all the annotation of the field to get the ValuesAttribute one
+            Field valuesField = this.getClass().getDeclaredField(MINIMAL_VALUE_ATTRIBUTE_FIELD_NAME);
+            for (Annotation annotation : valuesField.getDeclaredAnnotations()) {
+                //Once the annotation is get, decode it.
+                if (annotation instanceof ValuesAttribute) {
+                    annotationFound = true;
+                    ValuesAttribute valuesAnnotation = (ValuesAttribute) annotation;
+                    object = ObjectAnnotationConverter.annotationToObject(valuesAnnotation);
+                }
+            }
+
+            //If the annotation hasn't been found, the test has failed.
+            if (!annotationFound) {
+                Assert.fail("Unable to get the annotation '@ValuesAttribute' from the field '" +
+                        MINIMAL_VALUE_ATTRIBUTE_FIELD_NAME + "'.");
+            }
+            boolean conditionValue = object == null;
+            if(!conditionValue) {
+                String messageValue = "The value is not the one expected (" +
+                        ((ValueType) object).getValue() + " instead of " + null;
+                Assert.assertTrue(messageValue, conditionValue);
+            }
+
+        } catch (NoSuchFieldException e) {
+            Assert.fail("Unable to get the field '" + MINIMAL_VALUE_ATTRIBUTE_FIELD_NAME + "' from the class '" +
                     this.getClass().getCanonicalName() + "'.");
         }
     }

--- a/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/controller/utils/ValuesConvertTest.java
+++ b/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/controller/utils/ValuesConvertTest.java
@@ -1,0 +1,190 @@
+package org.orbisgis.wpsservice.controller.utils;
+
+import net.opengis.ows.v_2_0.RangeType;
+import net.opengis.ows.v_2_0.ValueType;
+import org.junit.Assert;
+import org.junit.Test;
+import org.orbisgis.wpsgroovyapi.attributes.*;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+
+/**
+ * @author Sylvain PALOMINOS
+ */
+public class ValuesConvertTest {
+
+
+    /*********************
+     * FULL RANGE VALUES *
+     *********************/
+
+    /** Field containing the full Values annotation. */
+    @ValuesAttribute(
+            type = ValuesType.RANGE,
+            maximum = "maximum",
+            minimum = "minimum",
+            spacing = "spacing",
+            value = "value"
+    )
+    public Object fullRangeValuesAttribute;
+    /** Name of the field containing the fullRangeValuesAttribute annotation. */
+    private static final String FULL_RANGE_VALUES_ATTRIBUTE_FIELD_NAME = "fullRangeValuesAttribute";
+
+    /**
+     * Test if the decoding and convert of the full range Values annotation into its java object is valid.
+     */
+    @Test
+    public void testFullRangeValuesAttributeConvert() {
+        try {
+            boolean annotationFound = false;
+            //Retrieve the Values object
+            Object object = null;
+            //Inspect all the annotation of the field to get the ValuesAttribute one
+            Field valuesField = this.getClass().getDeclaredField(FULL_RANGE_VALUES_ATTRIBUTE_FIELD_NAME);
+            for (Annotation annotation : valuesField.getDeclaredAnnotations()) {
+                //Once the annotation is get, decode it.
+                if (annotation instanceof ValuesAttribute) {
+                    annotationFound = true;
+                    ValuesAttribute valuesAnnotation = (ValuesAttribute) annotation;
+                    object = ObjectAnnotationConverter.annotationToObject(valuesAnnotation);
+                }
+            }
+
+            //If the annotation hasn't been found, the test has failed.
+            if (!annotationFound || object == null) {
+                Assert.fail("Unable to get the annotation '@ValuesAttribute' from the field '" +
+                        FULL_RANGE_VALUES_ATTRIBUTE_FIELD_NAME + "'.");
+            }
+            String messageClass = "The parsed value should be a '"+RangeType.class.getCanonicalName()+"' instance of '"+
+                    object.getClass().getCanonicalName()+"'.";
+            boolean conditionClass = object instanceof RangeType;
+            Assert.assertTrue(messageClass, conditionClass);
+
+            RangeType rangeType = (RangeType) object;
+
+            ////////////////////////////////////
+            // Build the Range Values to test //
+            ////////////////////////////////////
+
+            RangeType toTest = new RangeType();
+
+            ValueType maximumValue = new ValueType();
+            maximumValue.setValue("maximum");
+            toTest.setMaximumValue(maximumValue);
+
+            ValueType minimumValue = new ValueType();
+            minimumValue.setValue("minimum");
+            toTest.setMinimumValue(minimumValue);
+
+            ValueType spacingValue = new ValueType();
+            spacingValue.setValue("spacing");
+            toTest.setSpacing(spacingValue);
+
+            ////////////////////////////
+            // Tests the Range Values //
+            ////////////////////////////
+
+            //Test the maximum
+            String messageMaximum = "The maximum value is not the one expected (" +
+                    rangeType.getMaximumValue().getValue() + " instead of " + toTest.getMaximumValue().getValue();
+            boolean conditionMaximum = rangeType.getMaximumValue().getValue().equals(toTest.getMaximumValue().getValue());
+            Assert.assertTrue(messageMaximum, conditionMaximum);
+
+            //Test the minimum
+            String messageMinimum = "The minimum value is not the one expected (" +
+                    rangeType.getMinimumValue().getValue() + " instead of " + toTest.getMinimumValue().getValue();
+            boolean conditionMinimum = rangeType.getMinimumValue().getValue().equals(toTest.getMinimumValue().getValue());
+            Assert.assertTrue(messageMinimum, conditionMinimum);
+
+            //Test the spacing
+            String messageSpacing = "The spacing value is not the one expected (" +
+                    rangeType.getSpacing().getValue() + " instead of " + toTest.getSpacing().getValue();
+            boolean conditionSpacing = rangeType.getSpacing().getValue().equals(toTest.getSpacing().getValue());
+            Assert.assertTrue(messageSpacing, conditionSpacing);
+
+        } catch (NoSuchFieldException e) {
+            Assert.fail("Unable to get the field '" + FULL_RANGE_VALUES_ATTRIBUTE_FIELD_NAME + "' from the class '" +
+                    this.getClass().getCanonicalName() + "'.");
+        }
+    }
+
+
+    /************************
+     * MINIMAL RANGE VALUES *
+     ************************/
+
+    /** Field containing the minimal Range Values annotation. */
+    @ValuesAttribute(
+            type = ValuesType.RANGE
+    )
+    public Object minimalRangeValuesAttribute;
+    /** Name of the field containing the minimalRangeValuesAttribute annotation. */
+    private static final String MINIMAL_RANGE_VALUES_ATTRIBUTE_FIELD_NAME = "minimalRangeValuesAttribute";
+
+    /**
+     * Test if the decoding and convert of the minimal range Values annotation into its java object is valid.
+     */
+    @Test
+    public void testMinimalRangeValuesAttributeConvert() {
+        try {
+            boolean annotationFound = false;
+            //Retrieve the Values object
+            Object object = null;
+            //Inspect all the annotation of the field to get the ValuesAttribute one
+            Field valuesField = this.getClass().getDeclaredField(MINIMAL_RANGE_VALUES_ATTRIBUTE_FIELD_NAME);
+            for (Annotation annotation : valuesField.getDeclaredAnnotations()) {
+                //Once the annotation is get, decode it.
+                if (annotation instanceof ValuesAttribute) {
+                    annotationFound = true;
+                    ValuesAttribute valuesAnnotation = (ValuesAttribute) annotation;
+                    object = ObjectAnnotationConverter.annotationToObject(valuesAnnotation);
+                }
+            }
+
+            //If the annotation hasn't been found, the test has failed.
+            if (!annotationFound || object == null) {
+                Assert.fail("Unable to get the annotation '@ValuesAttribute' from the field '" +
+                        MINIMAL_RANGE_VALUES_ATTRIBUTE_FIELD_NAME + "'.");
+            }
+            String messageClass = "The parsed value should be a '"+RangeType.class.getCanonicalName()+"' instance of '"+
+                    object.getClass().getCanonicalName()+"'.";
+            boolean conditionClass = object instanceof RangeType;
+            Assert.assertTrue(messageClass, conditionClass);
+
+            RangeType rangeType = (RangeType) object;
+
+            ////////////////////////////////////
+            // Build the Range Values to test //
+            ////////////////////////////////////
+
+            RangeType toTest = new RangeType();
+
+            ////////////////////////////
+            // Tests the Range Values //
+            ////////////////////////////
+
+            //Test the maximum
+            String messageMaximum = "The maximum value is not the one expected (" +
+                    rangeType.getMaximumValue() + " instead of " + null;
+            boolean conditionMaximum = rangeType.getMaximumValue() == null;
+            Assert.assertTrue(messageMaximum, conditionMaximum);
+
+            //Test the minimum
+            String messageMinimum = "The minimum value is not the one expected (" +
+                    rangeType.getMinimumValue() + " instead of " + null;
+            boolean conditionMinimum = rangeType.getMinimumValue() == null;
+            Assert.assertTrue(messageMinimum, conditionMinimum);
+
+            //Test the spacing
+            String messageSpacing = "The spacing value is not the one expected (" +
+                    rangeType.getSpacing() + " instead of " + null;
+            boolean conditionSpacing = rangeType.getSpacing() == null;
+            Assert.assertTrue(messageSpacing, conditionSpacing);
+
+        } catch (NoSuchFieldException e) {
+            Assert.fail("Unable to get the field '" + MINIMAL_RANGE_VALUES_ATTRIBUTE_FIELD_NAME + "' from the class '" +
+                    this.getClass().getCanonicalName() + "'.");
+        }
+    }
+}


### PR DESCRIPTION
Implements several tests about the wps groovy annotation conversion into java objects. (DescriptionType, Format, Metadata, Values)

Adds the traduced string for the keywords, titles and resumes (all optionals).
Changes the type of the keywords from String into String[].
Updates the ObjectAnnotationConverter class. 