### PR TITLE
Adds other annotation convert tests

### DIFF
--- a/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/attributes/LiteralDataAttribute.groovy
+++ b/bundles/wps-groovy-api/src/main/java/org/orbisgis/wpsgroovyapi/attributes/LiteralDataAttribute.groovy
@@ -39,8 +39,6 @@ import java.lang.annotation.RetentionPolicy
  *
  *
  * The following fields must be defined (mandatory) :
- *  - valueAttribute : LiteralValueAttribute
- *      Information about the literal value.
  *
  * The following fields can be defined (optional) :
  *  - formats : FormatAttribute[]
@@ -58,9 +56,6 @@ import java.lang.annotation.RetentionPolicy
 
     /** The valid domain for literal data */
     LiteralDataDomainAttribute[] validDomains() default []
-
-    /** The literal value information */
-    LiteralValueAttribute valueAttribute()
 
 
 

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/parser/DataFieldParser.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/parser/DataFieldParser.java
@@ -54,7 +54,7 @@ public class DataFieldParser implements Parser {
     public InputDescriptionType parseInput(Field f, Object defaultValue, String processId) {
         //Instantiate the DataField object
         DataFieldAttribute dataFieldAttribute = f.getAnnotation(DataFieldAttribute.class);
-        Format format = FormatFactory.getFormatFromExtension(FormatFactory.OTHER_EXTENSION);
+        Format format = FormatFactory.getFormatFromExtension(FormatFactory.TEXT_EXTENSION);
         URI dataStoreUri = URI.create(processId + ":input:" + dataFieldAttribute.dataStore());
         DataField dataField = ObjectAnnotationConverter.annotationToObject(dataFieldAttribute, format, dataStoreUri);
 
@@ -80,7 +80,7 @@ public class DataFieldParser implements Parser {
     public OutputDescriptionType parseOutput(Field f, String processId) {
         //Instantiate the DataField object
         DataFieldAttribute dataFieldAttribute = f.getAnnotation(DataFieldAttribute.class);
-        Format format = FormatFactory.getFormatFromExtension(FormatFactory.OTHER_EXTENSION);
+        Format format = FormatFactory.getFormatFromExtension(FormatFactory.TEXT_EXTENSION);
         URI dataStoreUri = URI.create(processId + ":output:" + dataFieldAttribute.dataStore());
         DataField dataField = ObjectAnnotationConverter.annotationToObject(dataFieldAttribute, format, dataStoreUri);
 

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/parser/DataStoreParser.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/parser/DataStoreParser.java
@@ -98,7 +98,7 @@ public class DataStoreParser implements Parser{
 
         //If there is no file format enable, add the "other" format to the format list but it won't be visible.
         if(formatList.isEmpty()) {
-            formatList.add(FormatFactory.getFormatFromExtension(FormatFactory.OTHER_EXTENSION));
+            formatList.add(FormatFactory.getFormatFromExtension(FormatFactory.TEXT_EXTENSION));
         }
         formatList.get(0).setDefault(true);
 

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/parser/EnumerationParser.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/parser/EnumerationParser.java
@@ -53,7 +53,7 @@ public class EnumerationParser implements Parser{
     public InputDescriptionType parseInput(Field f, Object defaultValue, String processId) {
         //Instantiate the DataStore and its formats
         EnumerationAttribute enumerationAttribute = f.getAnnotation(EnumerationAttribute.class);
-        Format format = FormatFactory.getFormatFromExtension(FormatFactory.OTHER_EXTENSION);
+        Format format = FormatFactory.getFormatFromExtension(FormatFactory.TEXT_EXTENSION);
         Enumeration enumeration = ObjectAnnotationConverter.annotationToObject(enumerationAttribute, format);
 
         InputDescriptionType input = new InputDescriptionType();
@@ -77,7 +77,7 @@ public class EnumerationParser implements Parser{
     public OutputDescriptionType parseOutput(Field f, String processId) {
         //Instantiate the DataStore and its formats
         EnumerationAttribute enumerationAttribute = f.getAnnotation(EnumerationAttribute.class);
-        Format format = FormatFactory.getFormatFromExtension(FormatFactory.OTHER_EXTENSION);
+        Format format = FormatFactory.getFormatFromExtension(FormatFactory.TEXT_EXTENSION);
         Enumeration enumeration = ObjectAnnotationConverter.annotationToObject(enumerationAttribute, format);
 
         OutputDescriptionType output = new OutputDescriptionType();

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/parser/FieldValueParser.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/parser/FieldValueParser.java
@@ -54,7 +54,7 @@ public class FieldValueParser implements Parser {
     public InputDescriptionType parseInput(Field f, Object defaultValue, String processId) {
         //Instantiate the FieldValue object
         FieldValueAttribute fieldValueAttribute = f.getAnnotation(FieldValueAttribute.class);
-        Format format = FormatFactory.getFormatFromExtension(FormatFactory.OTHER_EXTENSION);
+        Format format = FormatFactory.getFormatFromExtension(FormatFactory.TEXT_EXTENSION);
         URI dataFieldUri = URI.create(processId + ":input:" + fieldValueAttribute.dataField());
         FieldValue fieldValue = ObjectAnnotationConverter.annotationToObject(fieldValueAttribute, format, dataFieldUri);
 
@@ -80,7 +80,7 @@ public class FieldValueParser implements Parser {
     public OutputDescriptionType parseOutput(Field f, String processId) {
         //Instantiate the FieldValue object
         FieldValueAttribute fieldValueAttribute = f.getAnnotation(FieldValueAttribute.class);
-        Format format = FormatFactory.getFormatFromExtension(FormatFactory.OTHER_EXTENSION);
+        Format format = FormatFactory.getFormatFromExtension(FormatFactory.TEXT_EXTENSION);
         URI dataFieldUri = URI.create(processId + ":output:" + fieldValueAttribute.dataField());
         FieldValue fieldValue = ObjectAnnotationConverter.annotationToObject(fieldValueAttribute, format, dataFieldUri);
 

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/parser/GeometryParser.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/parser/GeometryParser.java
@@ -52,7 +52,7 @@ public class GeometryParser implements Parser {
     @Override
     public InputDescriptionType parseInput(Field f, Object defaultValue, String processId) {
         //Instantiate the RawData
-        Format format = FormatFactory.getFormatFromExtension(FormatFactory.OTHER_EXTENSION);
+        Format format = FormatFactory.getFormatFromExtension(FormatFactory.TEXT_EXTENSION);
         GeometryData geometryData = ObjectAnnotationConverter.annotationToObject(f.getAnnotation(GeometryAttribute.class), format);
 
         InputDescriptionType input = new InputDescriptionType();
@@ -75,7 +75,7 @@ public class GeometryParser implements Parser {
     @Override
     public OutputDescriptionType parseOutput(Field f, String processId) {
         //Instantiate the RawData
-        Format format = FormatFactory.getFormatFromExtension(FormatFactory.OTHER_EXTENSION);
+        Format format = FormatFactory.getFormatFromExtension(FormatFactory.TEXT_EXTENSION);
         GeometryData geometryData = ObjectAnnotationConverter.annotationToObject(f.getAnnotation(GeometryAttribute.class), format);
 
         OutputDescriptionType output = new OutputDescriptionType();

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/parser/RawDataParser.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/parser/RawDataParser.java
@@ -52,7 +52,7 @@ public class RawDataParser implements Parser {
     @Override
     public InputDescriptionType parseInput(Field f, Object defaultValue, String processId) {
         //Instantiate the RawData
-        Format format = FormatFactory.getFormatFromExtension(FormatFactory.OTHER_EXTENSION);
+        Format format = FormatFactory.getFormatFromExtension(FormatFactory.TEXT_EXTENSION);
         RawData rawData = ObjectAnnotationConverter.annotationToObject(f.getAnnotation(RawDataAttribute.class), format);
 
         InputDescriptionType input = new InputDescriptionType();
@@ -75,7 +75,7 @@ public class RawDataParser implements Parser {
     @Override
     public OutputDescriptionType parseOutput(Field f, String processId) {
         //Instantiate the RawData
-        Format format = FormatFactory.getFormatFromExtension(FormatFactory.OTHER_EXTENSION);
+        Format format = FormatFactory.getFormatFromExtension(FormatFactory.TEXT_EXTENSION);
         RawData rawData = ObjectAnnotationConverter.annotationToObject(f.getAnnotation(RawDataAttribute.class), format);
 
         OutputDescriptionType output = new OutputDescriptionType();

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/utils/FormatFactory.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/utils/FormatFactory.java
@@ -36,7 +36,7 @@ public class FormatFactory {
     public static final String SQL_EXTENSION = "sqlTable";
     public static final String WKT_EXTENSION = "wkt";
     public static final String GEOMETRY_EXTENSION = "geometry";
-    public static final String OTHER_EXTENSION = "*";
+    public static final String TEXT_EXTENSION = ".txt";
 
     public static final String GEOCATALOG_EXTENSION = "geocatalog";
     public static final String DATABASE_EXTENSION = "dataBase";
@@ -45,7 +45,7 @@ public class FormatFactory {
     public static final String GEOJSON_MIMETYPE = "application/json";
     public static final String SQL_MIMETYPE = "custom/sql";
     public static final String WKT_MIMETYPE = "custom/wkt";
-    public static final String OTHER_MIMETYPE = "custom/other";
+    public static final String TEXT_MIMETYPE = "text/plain";
 
     public static final String SHAPEFILE_URI = "https://tools.ietf.org/html/rfc2046";
     public static final String GEOJSON_URI = "https://tools.ietf.org/html/rfc4627";
@@ -82,7 +82,7 @@ public class FormatFactory {
                 format.setSchema(WKT_URI);
                 break;
             default:
-                format.setMimeType(OTHER_MIMETYPE);
+                format.setMimeType(TEXT_MIMETYPE);
                 format.setSchema(OTHER_URI);
                 break;
         }
@@ -130,8 +130,8 @@ public class FormatFactory {
                 return SQL_DESCRIPTION;
             case WKT_MIMETYPE:
                 return WKT_DESCRIPTION;
-            case OTHER_MIMETYPE:
-                return OTHER_EXTENSION;
+            case TEXT_MIMETYPE:
+                return TEXT_EXTENSION;
             default:
                 return format.getMimeType();
         }
@@ -152,8 +152,8 @@ public class FormatFactory {
                 return SQL_DESCRIPTION;
             case WKT_MIMETYPE:
                 return WKT_DESCRIPTION;
-            case OTHER_MIMETYPE:
-                return OTHER_EXTENSION;
+            case TEXT_MIMETYPE:
+                return TEXT_EXTENSION;
             default:
                 return format.getMimeType();
         }

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/utils/ObjectAnnotationConverter.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/utils/ObjectAnnotationConverter.java
@@ -233,7 +233,7 @@ public class ObjectAnnotationConverter {
 
         List<Format> formatList = new ArrayList<>();
         if(literalDataAttribute.formats().length == 0){
-            formatList.add(FormatFactory.getFormatFromExtension(""));
+            formatList.add(FormatFactory.getFormatFromExtension(FormatFactory.TEXT_EXTENSION));
             formatList.get(0).setDefault(true);
         }
         else {

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/utils/ObjectAnnotationConverter.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/utils/ObjectAnnotationConverter.java
@@ -237,8 +237,16 @@ public class ObjectAnnotationConverter {
             formatList.get(0).setDefault(true);
         }
         else {
+            boolean isDefault = false;
             for (FormatAttribute formatAttribute : literalDataAttribute.formats()) {
-                formatList.add(ObjectAnnotationConverter.annotationToObject(formatAttribute));
+                Format format = ObjectAnnotationConverter.annotationToObject(formatAttribute);
+                if(format.isDefault()){
+                    isDefault = true;
+                }
+                formatList.add(format);
+            }
+            if(!isDefault){
+                formatList.get(0).setDefault(true);
             }
         }
         literalDataType.setFormat(formatList);
@@ -259,8 +267,16 @@ public class ObjectAnnotationConverter {
             lddList.add(literalDataDomain);
         }
         else {
+            boolean isDefault = false;
             for (LiteralDataDomainAttribute literalDataDomainAttribute : literalDataAttribute.validDomains()) {
-                lddList.add(ObjectAnnotationConverter.annotationToObject(literalDataDomainAttribute));
+                LiteralDataDomain ldd = ObjectAnnotationConverter.annotationToObject(literalDataDomainAttribute);
+                if(ldd.isDefault()){
+                    isDefault = true;
+                }
+                lddList.add(ldd);
+            }
+            if(!isDefault){
+                lddList.get(0).setDefault(true);
             }
         }
         literalDataType.setLiteralDataDomain(lddList);

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/utils/ObjectAnnotationConverter.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/utils/ObjectAnnotationConverter.java
@@ -211,8 +211,7 @@ public class ObjectAnnotationConverter {
         domainDataType.setValue(dataType.name());
         literalDataDomain.setDataType(domainDataType);
 
-        Object value = ObjectAnnotationConverter.annotationToObject(
-                literalDataDomainAttribute.possibleLiteralValues());
+        Object value = ObjectAnnotationConverter.annotationToObject(literalDataDomainAttribute.possibleLiteralValues());
         if(value instanceof AllowedValues){
             literalDataDomain.setAllowedValues((AllowedValues)value);
         }
@@ -293,23 +292,28 @@ public class ObjectAnnotationConverter {
 
     public static Object annotationToObject(
             PossibleLiteralValuesChoiceAttribute possibleLiteralValuesChoiceAttribute){
-            if(possibleLiteralValuesChoiceAttribute.allowedValues().length != 0){
-                AllowedValues allowedValues = new AllowedValues();
-                List<Object> valueList = new ArrayList<>();
-                for(ValuesAttribute va : possibleLiteralValuesChoiceAttribute.allowedValues()){
-                    valueList.add(ObjectAnnotationConverter.annotationToObject(va));
-                }
-                allowedValues.setValueOrRange(valueList);
-                return allowedValues;
-            }
-            else if (!possibleLiteralValuesChoiceAttribute.reference().isEmpty()){
-                ValuesReference valuesReference = new ValuesReference();
-                URI uri = URI.create(possibleLiteralValuesChoiceAttribute.reference());
-                valuesReference.setValue(uri.getPath());
-                valuesReference.setReference(uri.toString());
-                return valuesReference;
-            }
+        if(possibleLiteralValuesChoiceAttribute.anyValues() ||
+                (possibleLiteralValuesChoiceAttribute.allowedValues().length != 0 &&
+                        !possibleLiteralValuesChoiceAttribute.reference().isEmpty())){
             return new AnyValue();
+        }
+        else if(possibleLiteralValuesChoiceAttribute.allowedValues().length != 0){
+            AllowedValues allowedValues = new AllowedValues();
+            List<Object> valueList = new ArrayList<>();
+            for(ValuesAttribute va : possibleLiteralValuesChoiceAttribute.allowedValues()){
+                valueList.add(ObjectAnnotationConverter.annotationToObject(va));
+            }
+            allowedValues.setValueOrRange(valueList);
+            return allowedValues;
+        }
+        else if (!possibleLiteralValuesChoiceAttribute.reference().isEmpty()){
+            ValuesReference valuesReference = new ValuesReference();
+            URI uri = URI.create(possibleLiteralValuesChoiceAttribute.reference());
+            valuesReference.setValue(uri.getPath());
+            valuesReference.setReference(uri.toString());
+            return valuesReference;
+        }
+        return new AnyValue();
     }
 
     public static void annotationToObject(ProcessAttribute processAttribute, ProcessDescriptionType process){

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/model/DataType.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/model/DataType.java
@@ -33,8 +33,6 @@ import java.net.URISyntaxException;
  * @author Sylvain PALOMINOS
  */
 
-
-@Deprecated
 public enum DataType {
     //LiteralData types
     NUMBER("number"),

--- a/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/controller/utils/InputDescriptionTypeConvertTest.java
+++ b/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/controller/utils/InputDescriptionTypeConvertTest.java
@@ -1,0 +1,151 @@
+package org.orbisgis.wpsservice.controller.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.orbisgis.wpsgroovyapi.attributes.InputAttribute;
+import net.opengis.wps.v_2_0.*;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.math.BigInteger;
+
+/**
+ * @author Sylvain PALOMINOS
+ */
+public class InputDescriptionTypeConvertTest {
+
+    /*******************************
+     * FULL INPUT DESCRIPTION TYPE *
+     *******************************/
+
+    /** Field containing the full annotation. */
+    @InputAttribute(
+            minOccurs = 0,
+            maxOccurs = 10
+    )
+    public Object fullInputAttribute;
+    /** Name of the field containing the fullRangeAttribute annotation. */
+    private static final String FULL_INPUT_ATTRIBUTE_FIELD_NAME = "fullInputAttribute";
+
+    /**
+     * Test if the decoding and convert of the full inputDescriptionType annotation into its java object is valid.
+     */
+    @Test
+    public void testFullInputDescriptionTypeAttributeConvert() {
+        try {
+            boolean annotationFound = false;
+            //Retrieve the InputDescriptionType object
+            InputDescriptionType inputDescriptionType = new InputDescriptionType();
+            //Inspect all the annotation of the field to get the InputAttribute one
+            Field inputField = this.getClass().getDeclaredField(FULL_INPUT_ATTRIBUTE_FIELD_NAME);
+            for (Annotation annotation : inputField.getDeclaredAnnotations()) {
+                //Once the annotation is get, decode it.
+                if (annotation instanceof InputAttribute) {
+                    annotationFound = true;
+                    InputAttribute inputAnnotation = (InputAttribute) annotation;
+                    ObjectAnnotationConverter.annotationToObject(inputAnnotation, inputDescriptionType);
+                }
+            }
+
+            //If the annotation hasn't been found, the test has failed.
+            if (!annotationFound) {
+                Assert.fail("Unable to get the annotation '@ValuesAttribute' from the field '" +
+                        FULL_INPUT_ATTRIBUTE_FIELD_NAME + "'.");
+            }
+
+            ////////////////////////////////////////////
+            // Build the InputDescriptionType to test //
+            ////////////////////////////////////////////
+
+            InputDescriptionType toTest = new InputDescriptionType();
+            toTest.setMaxOccurs("10");
+            toTest.setMinOccurs(new BigInteger("0"));
+
+            ////////////////////////////////////
+            // Tests the InputDescriptionType //
+            ////////////////////////////////////
+
+            //Test the max occurs
+            String messageMaxOccurs = "The max occurs value is not the one expected (" +
+                    inputDescriptionType.getMaxOccurs() + " instead of " + toTest.getMaxOccurs();
+            boolean conditionMaxOccurs = inputDescriptionType.getMaxOccurs().equals(toTest.getMaxOccurs());
+            Assert.assertTrue(messageMaxOccurs, conditionMaxOccurs);
+
+            //Test the min occurs
+            String messageMinOccurs = "The min occurs value is not the one expected (" +
+                    inputDescriptionType.getMinOccurs() + " instead of " + toTest.getMinOccurs();
+            boolean conditionMinOccurs = inputDescriptionType.getMinOccurs().equals(toTest.getMinOccurs());
+            Assert.assertTrue(messageMinOccurs, conditionMinOccurs);
+
+        } catch (NoSuchFieldException e) {
+            Assert.fail("Unable to get the field '" + FULL_INPUT_ATTRIBUTE_FIELD_NAME + "' from the class '" +
+                    this.getClass().getCanonicalName() + "'.");
+        }
+    }
+
+    /**********************************
+     * MINIMAL INPUT DESCRIPTION TYPE *
+     **********************************/
+
+    /** Field containing the minimal annotation. */
+    @InputAttribute()
+    public Object minimalInputAttribute;
+    /** Name of the field containing the minimalRangeAttribute annotation. */
+    private static final String MINIMAL_INPUT_ATTRIBUTE_FIELD_NAME = "minimalInputAttribute";
+
+    /**
+     * Test if the decoding and convert of the minimal inputDescriptionType annotation into its java object is valid.
+     */
+    @Test
+    public void testMinimalInputDescriptionTypeAttributeConvert() {
+        try {
+            boolean annotationFound = false;
+            //Retrieve the InputDescriptionType object
+            InputDescriptionType inputDescriptionType = new InputDescriptionType();
+            //Inspect all the annotation of the field to get the InputAttribute one
+            Field inputField = this.getClass().getDeclaredField(MINIMAL_INPUT_ATTRIBUTE_FIELD_NAME);
+            for (Annotation annotation : inputField.getDeclaredAnnotations()) {
+                //Once the annotation is get, decode it.
+                if (annotation instanceof InputAttribute) {
+                    annotationFound = true;
+                    InputAttribute inputAnnotation = (InputAttribute) annotation;
+                    ObjectAnnotationConverter.annotationToObject(inputAnnotation, inputDescriptionType);
+                }
+            }
+
+            //If the annotation hasn't been found, the test has failed.
+            if (!annotationFound) {
+                Assert.fail("Unable to get the annotation '@ValuesAttribute' from the field '" +
+                        MINIMAL_INPUT_ATTRIBUTE_FIELD_NAME + "'.");
+            }
+
+            ////////////////////////////////////////////
+            // Build the InputDescriptionType to test //
+            ////////////////////////////////////////////
+
+            InputDescriptionType toTest = new InputDescriptionType();
+            toTest.setMaxOccurs(""+InputAttribute.defaultMaxOccurs);
+            toTest.setMinOccurs(new BigInteger(""+InputAttribute.defaultMinOccurs));
+
+            ////////////////////////////////////
+            // Tests the InputDescriptionType //
+            ////////////////////////////////////
+
+            //Test the max occurs
+            String messageMaxOccurs = "The max occurs value is not the one expected (" +
+                    inputDescriptionType.getMaxOccurs() + " instead of " + toTest.getMaxOccurs();
+            boolean conditionMaxOccurs = inputDescriptionType.getMaxOccurs().equals(toTest.getMaxOccurs());
+            Assert.assertTrue(messageMaxOccurs, conditionMaxOccurs);
+
+            //Test the min occurs
+            String messageMinOccurs = "The min occurs value is not the one expected (" +
+                    inputDescriptionType.getMinOccurs() + " instead of " + toTest.getMinOccurs();
+            boolean conditionMinOccurs = inputDescriptionType.getMinOccurs().equals(toTest.getMinOccurs());
+            Assert.assertTrue(messageMinOccurs, conditionMinOccurs);
+
+        } catch (NoSuchFieldException e) {
+            Assert.fail("Unable to get the field '" + MINIMAL_INPUT_ATTRIBUTE_FIELD_NAME + "' from the class '" +
+                    this.getClass().getCanonicalName() + "'.");
+        }
+    }
+}

--- a/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/controller/utils/LiteralDataDomainConvertTest.java
+++ b/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/controller/utils/LiteralDataDomainConvertTest.java
@@ -1,0 +1,229 @@
+package org.orbisgis.wpsservice.controller.utils;
+
+import net.opengis.ows.v_2_0.AnyValue;
+import net.opengis.ows.v_2_0.DomainMetadataType;
+import net.opengis.ows.v_2_0.ValueType;
+import net.opengis.wps.v_2_0.LiteralDataType.LiteralDataDomain;
+import org.junit.Assert;
+import org.junit.Test;
+import org.orbisgis.wpsgroovyapi.attributes.LiteralDataDomainAttribute;
+import org.orbisgis.wpsgroovyapi.attributes.PossibleLiteralValuesChoiceAttribute;
+import org.orbisgis.wpsgroovyapi.attributes.ValuesAttribute;
+import org.orbisgis.wpsgroovyapi.attributes.ValuesType;
+import org.orbisgis.wpsservice.model.DataType;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+
+/**
+ * @author Sylvain PALOMINOS
+ */
+public class LiteralDataDomainConvertTest {
+
+    /****************************
+     * FULL LITERAL DATA DOMAIN *
+     ****************************/
+
+    /** Field containing the full LiteralDataDomain annotation. */
+    @LiteralDataDomainAttribute(
+            possibleLiteralValues = @PossibleLiteralValuesChoiceAttribute(
+                    allowedValues = {
+                            @ValuesAttribute(value = "value", type = ValuesType.VALUE),
+                            @ValuesAttribute(maximum = "maximum", minimum = "minimum", type = ValuesType.RANGE)
+                    },
+                    reference = "reference",
+                    anyValues = true
+            ),
+            dataType = "STRING",
+            uom = "uom://test/uom",
+            defaultValue = @ValuesAttribute(value = "value"),
+            isDefault = true
+    )
+    public Object fullLiteralDataDomainAttribute;
+    /** Name of the field containing the fullLiteralDataDomainAttribute annotation. */
+    private static final String FULL_LITERAL_DATA_DOMAIN_ATTRIBUTE_FIELD_NAME = "fullLiteralDataDomainAttribute";
+
+    /**
+     * Test if the decoding and convert of the full literalDataDomain annotation into its java object is valid.
+     */
+    @Test
+    public void testFullLiteralDataDomainAttributeConvert() {
+        try {
+            boolean annotationFound = false;
+            //Retrieve the LiteralDataDomain object
+            LiteralDataDomain literalDataDomain = null;
+            //Inspect all the annotation of the field to get the LiteralDataDomainAttribute one
+            Field valuesField = this.getClass().getDeclaredField(FULL_LITERAL_DATA_DOMAIN_ATTRIBUTE_FIELD_NAME);
+            for (Annotation annotation : valuesField.getDeclaredAnnotations()) {
+                //Once the annotation is get, decode it.
+                if (annotation instanceof LiteralDataDomainAttribute) {
+                    annotationFound = true;
+                    LiteralDataDomainAttribute literalDataDomainAnnotation = (LiteralDataDomainAttribute) annotation;
+                    literalDataDomain = ObjectAnnotationConverter.annotationToObject(literalDataDomainAnnotation);
+                }
+            }
+
+            //If the annotation hasn't been found, the test has failed.
+            if (!annotationFound || literalDataDomain == null) {
+                Assert.fail("Unable to get the annotation '@LiteraldataDomainAttribute' from the field '" +
+                        FULL_LITERAL_DATA_DOMAIN_ATTRIBUTE_FIELD_NAME + "'.");
+            }
+
+            /////////////////////////////////////////
+            // Build the LiteralDataDomain to test //
+            /////////////////////////////////////////
+
+            LiteralDataDomain toTest = new LiteralDataDomain();
+            toTest.setDefault(true);
+            toTest.setAnyValue(new AnyValue());
+            DomainMetadataType domainMetadataType = new DomainMetadataType();
+            domainMetadataType.setReference(DataType.STRING.getUri().toString());
+            domainMetadataType.setValue(DataType.STRING.name());
+            toTest.setDataType(domainMetadataType);
+            ValueType defaultValue = new ValueType();
+            defaultValue.setValue("value");
+            toTest.setDefaultValue(defaultValue);
+            DomainMetadataType uom = new DomainMetadataType();
+            uom.setValue("/uom");
+            uom.setReference("uom://test/uom");
+            toTest.setUOM(uom);
+
+            /////////////////////////////////
+            // Tests the LiteralDataDomain //
+            /////////////////////////////////
+
+            //Test the value
+            String messageValue = "The value is not the one expected (AnyValue object expected)";
+            boolean conditionValue = literalDataDomain.getAnyValue()!= null;
+            Assert.assertTrue(messageValue, conditionValue);
+
+            //Test the default state
+            String messageDefaultState = "The default state is not the one expected (" +
+                    literalDataDomain.isDefault() + " instead of " + toTest.isDefault();
+            boolean conditionDefaultState = literalDataDomain.isDefault() == toTest.isDefault();
+            Assert.assertTrue(messageDefaultState, conditionDefaultState);
+
+            //Test the dataType
+            String messageDataType = "The data type is not the one expected (" +
+                    literalDataDomain.getDataType().getValue()+"/"+ literalDataDomain.getDataType().getReference() +
+                    " instead of " + toTest.getDataType().getValue()+"/"+ toTest.getDataType().getReference();
+            boolean conditionDataType =
+                    literalDataDomain.getDataType().getValue().equals(toTest.getDataType().getValue()) &&
+                            literalDataDomain.getDataType().getReference().equals(toTest.getDataType().getReference());
+            Assert.assertTrue(messageDataType, conditionDataType);
+
+            //Test the default value
+            String messageDefaultValue = "The default value is not the one expected (" +
+                    literalDataDomain.getDefaultValue().getValue()+" instead of "+toTest.getDefaultValue().getValue();
+            boolean conditionDefaultValue =
+                    literalDataDomain.getDefaultValue().getValue().equals(toTest.getDefaultValue().getValue());
+            Assert.assertTrue(messageDefaultValue, conditionDefaultValue);
+
+            //Test the uom
+            String messageUom = "The uom is not the one expected (" +
+                    literalDataDomain.getUOM().getValue()+" , "+ literalDataDomain.getUOM().getReference() +
+                    " instead of " + toTest.getUOM().getValue()+" , "+ toTest.getUOM().getReference();
+            boolean conditionUom =
+                    literalDataDomain.getUOM().getValue().equals(toTest.getUOM().getValue()) &&
+                            literalDataDomain.getUOM().getReference().equals(toTest.getUOM().getReference());
+            Assert.assertTrue(messageUom, conditionUom);
+
+        } catch (NoSuchFieldException e) {
+            Assert.fail("Unable to get the field '" + FULL_LITERAL_DATA_DOMAIN_ATTRIBUTE_FIELD_NAME + "' from the class '" +
+                    this.getClass().getCanonicalName() + "'.");
+        }
+    }
+
+
+    /*******************************
+     * MINIMAL LITERAL DATA DOMAIN *
+     *******************************/
+
+    /** Field containing the minimal LiteralDataDomain annotation. */
+    @LiteralDataDomainAttribute(
+            possibleLiteralValues = @PossibleLiteralValuesChoiceAttribute(),
+            dataType = "STRING",
+            defaultValue = @ValuesAttribute(value = "value")
+    )
+    public Object minimalLiteralDataDomainAttribute;
+    /** Name of the field containing the minimalLiteralDataDomainAttribute annotation. */
+    private static final String MINIMAL_LITERAL_DATA_DOMAIN_ATTRIBUTE_FIELD_NAME = "minimalLiteralDataDomainAttribute";
+
+    /**
+     * Test if the decoding and convert of the minimal literalDataDomain annotation into its java object is valid.
+     */
+    @Test
+    public void testMinimalLiteralDataDomainAttributeConvert() {
+        try {
+            boolean annotationFound = false;
+            //Retrieve the LiteralDataDomain object
+            LiteralDataDomain literalDataDomain = null;
+            //Inspect all the annotation of the field to get the LiteralDataDomainAttribute one
+            Field valuesField = this.getClass().getDeclaredField(MINIMAL_LITERAL_DATA_DOMAIN_ATTRIBUTE_FIELD_NAME);
+            for (Annotation annotation : valuesField.getDeclaredAnnotations()) {
+                //Once the annotation is get, decode it.
+                if (annotation instanceof LiteralDataDomainAttribute) {
+                    annotationFound = true;
+                    LiteralDataDomainAttribute literalDataDomainAnnotation = (LiteralDataDomainAttribute) annotation;
+                    literalDataDomain = ObjectAnnotationConverter.annotationToObject(literalDataDomainAnnotation);
+                }
+            }
+
+            //If the annotation hasn't been found, the test has failed.
+            if (!annotationFound || literalDataDomain == null) {
+                Assert.fail("Unable to get the annotation '@LiteraldataDomainAttribute' from the field '" +
+                        MINIMAL_LITERAL_DATA_DOMAIN_ATTRIBUTE_FIELD_NAME + "'.");
+            }
+
+            /////////////////////////////////////////
+            // Build the LiteralDataDomain to test //
+            /////////////////////////////////////////
+
+            LiteralDataDomain toTest = new LiteralDataDomain();
+            toTest.setDefault(false);
+            toTest.setAnyValue(new AnyValue());
+            DomainMetadataType domainMetadataType = new DomainMetadataType();
+            domainMetadataType.setReference(DataType.STRING.getUri().toString());
+            domainMetadataType.setValue(DataType.STRING.name());
+            toTest.setDataType(domainMetadataType);
+            ValueType defaultValue = new ValueType();
+            defaultValue.setValue("value");
+            toTest.setDefaultValue(defaultValue);
+
+            /////////////////////////////////
+            // Tests the LiteralDataDomain //
+            /////////////////////////////////
+
+            //Test the value
+            String messageValue = "The value is not the one expected (AnyValue object expected)";
+            boolean conditionValue = literalDataDomain.getAnyValue()!= null;
+            Assert.assertTrue(messageValue, conditionValue);
+
+            //Test the default state
+            String messageDefaultState = "The default state is not the one expected (" +
+                    literalDataDomain.isDefault() + " instead of " + toTest.isDefault();
+            boolean conditionDefaultState = literalDataDomain.isDefault() == toTest.isDefault();
+            Assert.assertTrue(messageDefaultState, conditionDefaultState);
+
+            //Test the dataType
+            String messageDataType = "The data type is not the one expected (" +
+                    literalDataDomain.getDataType().getValue()+"/"+ literalDataDomain.getDataType().getReference() +
+                    " instead of " + toTest.getDataType().getValue()+"/"+ toTest.getDataType().getReference();
+            boolean conditionDataType =
+                    literalDataDomain.getDataType().getValue().equals(toTest.getDataType().getValue()) &&
+                            literalDataDomain.getDataType().getReference().equals(toTest.getDataType().getReference());
+            Assert.assertTrue(messageDataType, conditionDataType);
+
+            //Test the default value
+            String messageDefaultValue = "The default value is not the one expected (" +
+                    literalDataDomain.getDefaultValue().getValue()+" instead of "+toTest.getDefaultValue().getValue();
+            boolean conditionDefaultValue =
+                    literalDataDomain.getDefaultValue().getValue().equals(toTest.getDefaultValue().getValue());
+            Assert.assertTrue(messageDefaultValue, conditionDefaultValue);
+
+        } catch (NoSuchFieldException e) {
+            Assert.fail("Unable to get the field '" + MINIMAL_LITERAL_DATA_DOMAIN_ATTRIBUTE_FIELD_NAME + "' from the class '" +
+                    this.getClass().getCanonicalName() + "'.");
+        }
+    }
+}

--- a/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/controller/utils/LiteralDataTypeConvertTest.java
+++ b/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/controller/utils/LiteralDataTypeConvertTest.java
@@ -1,0 +1,202 @@
+package org.orbisgis.wpsservice.controller.utils;
+
+import net.opengis.wps.v_2_0.Format;
+import net.opengis.wps.v_2_0.LiteralDataType;
+import org.junit.Assert;
+import org.junit.Test;
+import org.orbisgis.wpsgroovyapi.attributes.*;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+
+/**
+ * @author Sylvain PALOMINOS
+ */
+public class LiteralDataTypeConvertTest {
+    /*********************
+     * FULL LITERAL DATA *
+     *********************/
+
+    /** Field containing the full LiteralDataAttribute annotation. */
+    @LiteralDataAttribute(
+            formats = {
+                    @FormatAttribute(mimeType = "mimetype", schema = "schema"),
+                    @FormatAttribute(mimeType = "mimetype", schema = "schema")
+            },
+            validDomains = {
+                    @LiteralDataDomainAttribute(
+                            possibleLiteralValues = @PossibleLiteralValuesChoiceAttribute(),
+                            dataType = "STRING",
+                            defaultValue = @ValuesAttribute(value = "value")
+                    ),
+                    @LiteralDataDomainAttribute(
+                            possibleLiteralValues = @PossibleLiteralValuesChoiceAttribute(),
+                            dataType = "STRING",
+                            defaultValue = @ValuesAttribute(value = "value")
+                    )
+            }
+    )
+    public Object fullLiteralDataAttribute;
+    /** Name of the field containing the fullLiteralDataAttribute annotation. */
+    private static final String FULL_LITERAL_DATA_ATTRIBUTE_FIELD_NAME = "fullLiteralDataAttribute";
+
+    /**
+     * Test if the decoding and convert of the full literalData annotation into its java object is valid.
+     */
+    @Test
+    public void testFullLiteralDataAttributeConvert() {
+        try {
+            boolean annotationFound = false;
+            //Retrieve the LiteralData object
+            LiteralDataType literalDataType = null;
+            //Inspect all the annotation of the field to get the LiteralDataDomainAttribute one
+            Field valuesField = this.getClass().getDeclaredField(FULL_LITERAL_DATA_ATTRIBUTE_FIELD_NAME);
+            for (Annotation annotation : valuesField.getDeclaredAnnotations()) {
+                //Once the annotation is get, decode it.
+                if (annotation instanceof LiteralDataAttribute) {
+                    annotationFound = true;
+                    LiteralDataAttribute literalDataAnnotation = (LiteralDataAttribute) annotation;
+                    literalDataType = ObjectAnnotationConverter.annotationToObject(literalDataAnnotation);
+                }
+            }
+
+            //If the annotation hasn't been found, the test has failed.
+            if (!annotationFound || literalDataType == null) {
+                Assert.fail("Unable to get the annotation '@LiteraldataDomainAttribute' from the field '" +
+                        FULL_LITERAL_DATA_ATTRIBUTE_FIELD_NAME + "'.");
+            }
+
+            /////////////////////////////////
+            // Tests the LiteralDataDomain //
+            /////////////////////////////////
+
+            //Test there is only one default format
+            String messageFormat = "Only one format should be set as the default one.";
+            boolean isDefaultFormat = false;
+            boolean onlyOneDefaultFormat = true;
+            for(Format format : literalDataType.getFormat()){
+                if(format.isDefault() && isDefaultFormat){
+                    onlyOneDefaultFormat = false;
+                }
+                if(format.isDefault()){
+                    isDefaultFormat = true;
+                }
+            }
+            boolean conditionFormat = isDefaultFormat && onlyOneDefaultFormat;
+            Assert.assertTrue(messageFormat, conditionFormat);
+
+            //Test there is only one default literalDataDomain
+            String messageLdd = "Only one literalDataDomain should be set as the default one.";
+            boolean isDefaultLdd = false;
+            boolean onlyOneDefaultLdd = true;
+            for(LiteralDataType.LiteralDataDomain ldd : literalDataType.getLiteralDataDomain()){
+                if(ldd.isDefault() && isDefaultLdd){
+                    onlyOneDefaultLdd = false;
+                }
+                if(ldd.isDefault()){
+                    isDefaultLdd = true;
+                }
+            }
+            boolean conditionLdd = isDefaultLdd && onlyOneDefaultLdd;
+            Assert.assertTrue(messageFormat, conditionLdd);
+
+        } catch (NoSuchFieldException e) {
+            Assert.fail("Unable to get the field '" + FULL_LITERAL_DATA_ATTRIBUTE_FIELD_NAME + "' from the class '" +
+                    this.getClass().getCanonicalName() + "'.");
+        }
+    }
+
+
+    /************************
+     * MINIMAL LITERAL DATA *
+     ************************/
+
+    /** Field containing the minimal LiteralDataAttribute annotation. */
+    @LiteralDataAttribute(
+            formats = {
+                    @FormatAttribute(mimeType = "mimetype", schema = "schema"),
+                    @FormatAttribute(mimeType = "mimetype", schema = "schema")
+            },
+            validDomains = {
+                    @LiteralDataDomainAttribute(
+                            possibleLiteralValues = @PossibleLiteralValuesChoiceAttribute(),
+                            dataType = "STRING",
+                            defaultValue = @ValuesAttribute(value = "value")
+                    ),
+                    @LiteralDataDomainAttribute(
+                            possibleLiteralValues = @PossibleLiteralValuesChoiceAttribute(),
+                            dataType = "STRING",
+                            defaultValue = @ValuesAttribute(value = "value")
+                    )
+            }
+    )
+    public Object minimalLiteralDataAttribute;
+    /** Name of the field containing the minimalLiteralDataAttribute annotation. */
+    private static final String MINIMAL_LITERAL_DATA_ATTRIBUTE_FIELD_NAME = "minimalLiteralDataAttribute";
+
+    /**
+     * Test if the decoding and convert of the minimal literalData annotation into its java object is valid.
+     */
+    @Test
+    public void testMinimalLiteralDataAttributeConvert() {
+        try {
+            boolean annotationFound = false;
+            //Retrieve the LiteralData object
+            LiteralDataType literalDataType = null;
+            //Inspect all the annotation of the field to get the LiteralDataDomainAttribute one
+            Field valuesField = this.getClass().getDeclaredField(MINIMAL_LITERAL_DATA_ATTRIBUTE_FIELD_NAME);
+            for (Annotation annotation : valuesField.getDeclaredAnnotations()) {
+                //Once the annotation is get, decode it.
+                if (annotation instanceof LiteralDataAttribute) {
+                    annotationFound = true;
+                    LiteralDataAttribute literalDataAnnotation = (LiteralDataAttribute) annotation;
+                    literalDataType = ObjectAnnotationConverter.annotationToObject(literalDataAnnotation);
+                }
+            }
+
+            //If the annotation hasn't been found, the test has failed.
+            if (!annotationFound || literalDataType == null) {
+                Assert.fail("Unable to get the annotation '@LiteraldataDomainAttribute' from the field '" +
+                        MINIMAL_LITERAL_DATA_ATTRIBUTE_FIELD_NAME + "'.");
+            }
+
+            /////////////////////////////////
+            // Tests the LiteralDataDomain //
+            /////////////////////////////////
+
+            //Test there is only one default format
+            String messageFormat = "Only one format should be set as the default one.";
+            boolean isDefaultFormat = false;
+            boolean onlyOneDefaultFormat = true;
+            for(Format format : literalDataType.getFormat()){
+                if(format.isDefault() && isDefaultFormat){
+                    onlyOneDefaultFormat = false;
+                }
+                if(format.isDefault()){
+                    isDefaultFormat = true;
+                }
+            }
+            boolean conditionFormat = isDefaultFormat && onlyOneDefaultFormat;
+            Assert.assertTrue(messageFormat, conditionFormat);
+
+            //Test there is only one default literalDataDomain
+            String messageLdd = "Only one literalDataDomain should be set as the default one.";
+            boolean isDefaultLdd = false;
+            boolean onlyOneDefaultLdd = true;
+            for(LiteralDataType.LiteralDataDomain ldd : literalDataType.getLiteralDataDomain()){
+                if(ldd.isDefault() && isDefaultLdd){
+                    onlyOneDefaultLdd = false;
+                }
+                if(ldd.isDefault()){
+                    isDefaultLdd = true;
+                }
+            }
+            boolean conditionLdd = isDefaultLdd && onlyOneDefaultLdd;
+            Assert.assertTrue(messageFormat, conditionLdd);
+
+        } catch (NoSuchFieldException e) {
+            Assert.fail("Unable to get the field '" + MINIMAL_LITERAL_DATA_ATTRIBUTE_FIELD_NAME + "' from the class '" +
+                    this.getClass().getCanonicalName() + "'.");
+        }
+    }
+}

--- a/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/controller/utils/LiteralDataTypeConvertTest.java
+++ b/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/controller/utils/LiteralDataTypeConvertTest.java
@@ -98,7 +98,7 @@ public class LiteralDataTypeConvertTest {
                 }
             }
             boolean conditionLdd = isDefaultLdd && onlyOneDefaultLdd;
-            Assert.assertTrue(messageFormat, conditionLdd);
+            Assert.assertTrue(messageLdd, conditionLdd);
 
         } catch (NoSuchFieldException e) {
             Assert.fail("Unable to get the field '" + FULL_LITERAL_DATA_ATTRIBUTE_FIELD_NAME + "' from the class '" +
@@ -112,24 +112,7 @@ public class LiteralDataTypeConvertTest {
      ************************/
 
     /** Field containing the minimal LiteralDataAttribute annotation. */
-    @LiteralDataAttribute(
-            formats = {
-                    @FormatAttribute(mimeType = "mimetype", schema = "schema"),
-                    @FormatAttribute(mimeType = "mimetype", schema = "schema")
-            },
-            validDomains = {
-                    @LiteralDataDomainAttribute(
-                            possibleLiteralValues = @PossibleLiteralValuesChoiceAttribute(),
-                            dataType = "STRING",
-                            defaultValue = @ValuesAttribute(value = "value")
-                    ),
-                    @LiteralDataDomainAttribute(
-                            possibleLiteralValues = @PossibleLiteralValuesChoiceAttribute(),
-                            dataType = "STRING",
-                            defaultValue = @ValuesAttribute(value = "value")
-                    )
-            }
-    )
+    @LiteralDataAttribute()
     public Object minimalLiteralDataAttribute;
     /** Name of the field containing the minimalLiteralDataAttribute annotation. */
     private static final String MINIMAL_LITERAL_DATA_ATTRIBUTE_FIELD_NAME = "minimalLiteralDataAttribute";
@@ -192,7 +175,7 @@ public class LiteralDataTypeConvertTest {
                 }
             }
             boolean conditionLdd = isDefaultLdd && onlyOneDefaultLdd;
-            Assert.assertTrue(messageFormat, conditionLdd);
+            Assert.assertTrue(messageLdd, conditionLdd);
 
         } catch (NoSuchFieldException e) {
             Assert.fail("Unable to get the field '" + MINIMAL_LITERAL_DATA_ATTRIBUTE_FIELD_NAME + "' from the class '" +

--- a/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/controller/utils/PossibleLiteralValueConvertTest.java
+++ b/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/controller/utils/PossibleLiteralValueConvertTest.java
@@ -1,0 +1,267 @@
+package org.orbisgis.wpsservice.controller.utils;
+
+import net.opengis.ows.v_2_0.*;
+import net.opengis.wfs._2_1.PropertyType;
+import org.junit.Assert;
+import org.junit.Test;
+import org.orbisgis.wpsgroovyapi.attributes.PossibleLiteralValuesChoiceAttribute;
+import org.orbisgis.wpsgroovyapi.attributes.ValuesAttribute;
+import org.orbisgis.wpsgroovyapi.attributes.ValuesType;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.List;
+
+/**
+ * @author Sylvain PALOMINOS
+ */
+public class PossibleLiteralValueConvertTest {
+
+
+    /*************
+     * FULL PLVC *
+     *************/
+
+    /** Field containing the full annotation. */
+    @PossibleLiteralValuesChoiceAttribute()
+    public Object fullPLVCAttribute;
+    /** Name of the field containing the full PossibleLiteralValueChoice annotation. */
+    private static final String FULL_PLVC_ATTRIBUTE_FIELD_NAME = "fullPLVCAttribute";
+
+    /**
+     * Test if the decoding and convert of the full PossibleLiteralValueChoice annotation into its java object is valid.
+     */
+    @Test
+    public void testFullPLVCAttributeConvert() {
+        try {
+            boolean annotationFound = false;
+            //Retrieve the plvc object
+            Object object = null;
+            //Inspect all the annotation of the field to get the PLVCAttribute one
+            Field plvcField = this.getClass().getDeclaredField(FULL_PLVC_ATTRIBUTE_FIELD_NAME);
+            for (Annotation annotation : plvcField.getDeclaredAnnotations()) {
+                //Once the annotation is get, decode it.
+                if (annotation instanceof PossibleLiteralValuesChoiceAttribute) {
+                    annotationFound = true;
+                    PossibleLiteralValuesChoiceAttribute plvcAnnotation = (PossibleLiteralValuesChoiceAttribute) annotation;
+                    object = ObjectAnnotationConverter.annotationToObject(plvcAnnotation);
+                }
+            }
+
+            //If the annotation hasn't been found, the test has failed.
+            if (!annotationFound || object == null) {
+                Assert.fail("Unable to get the annotation '@ValuesAttribute' from the field '" +
+                        FULL_PLVC_ATTRIBUTE_FIELD_NAME + "'.");
+            }
+
+            ///////////////////////////
+            // Tests the PLVC Values //
+            ///////////////////////////
+
+            String messageClass = "The parsed value should be a '"+AnyValue.class.getCanonicalName()+"' instead of '"+
+                    object.getClass().getCanonicalName()+"'.";
+            boolean conditionClass = object instanceof AnyValue;
+            Assert.assertTrue(messageClass, conditionClass);
+
+        } catch (NoSuchFieldException e) {
+            Assert.fail("Unable to get the field '" + FULL_PLVC_ATTRIBUTE_FIELD_NAME + "' from the class '" +
+                    this.getClass().getCanonicalName() + "'.");
+        }
+    }
+
+
+    /*****************
+     * MINIMAL PLVC *
+     *****************/
+
+    /** Field containing the full annotation. */
+    @PossibleLiteralValuesChoiceAttribute()
+    public Object minimalPLVCAttribute;
+    /** Name of the field containing the minimalRangeAttribute annotation. */
+    private static final String MINIMAL_PLVC_ATTRIBUTE_FIELD_NAME = "minimalPLVCAttribute";
+
+    /**
+     * Test if the decoding and convert of the minimal possibleLiteralValuesChoice annotation into its java object is
+     * valid.
+     */
+    @Test
+    public void testMinimalPLVCAttributeConvert() {
+        try {
+            boolean annotationFound = false;
+            //Retrieve the plvc object
+            Object object = null;
+            //Inspect all the annotation of the field to get the PLVC one
+            Field plvcField = this.getClass().getDeclaredField(MINIMAL_PLVC_ATTRIBUTE_FIELD_NAME);
+            for (Annotation annotation : plvcField.getDeclaredAnnotations()) {
+                //Once the annotation is get, decode it.
+                if (annotation instanceof PossibleLiteralValuesChoiceAttribute) {
+                    annotationFound = true;
+                    PossibleLiteralValuesChoiceAttribute plvcAnnotation = (PossibleLiteralValuesChoiceAttribute) annotation;
+                    object = ObjectAnnotationConverter.annotationToObject(plvcAnnotation);
+                }
+            }
+
+            //If the annotation hasn't been found, the test has failed.
+            if (!annotationFound || object == null) {
+                Assert.fail("Unable to get the annotation '@ValuesAttribute' from the field '" +
+                        MINIMAL_PLVC_ATTRIBUTE_FIELD_NAME + "'.");
+            }
+
+            ///////////////////////////
+            // Tests the PLVC Values //
+            ///////////////////////////
+
+            String messageClass = "The parsed value should be a '"+AnyValue.class.getCanonicalName()+"' instead of '"+
+                    object.getClass().getCanonicalName()+"'.";
+            boolean conditionClass = object instanceof AnyValue;
+            Assert.assertTrue(messageClass, conditionClass);
+
+        } catch (NoSuchFieldException e) {
+            Assert.fail("Unable to get the field '" + MINIMAL_PLVC_ATTRIBUTE_FIELD_NAME + "' from the class '" +
+                    this.getClass().getCanonicalName() + "'.");
+        }
+    }
+
+
+    /******************
+     * REFERENCE PLVC *
+     ******************/
+
+    /** Field containing the plvc annotation. */
+    @PossibleLiteralValuesChoiceAttribute(
+            reference = "file://file/path"
+    )
+    public Object referencePLVCAttribute;
+    /** Name of the field containing the referencePLVCAttribute annotation. */
+    private static final String REFERENCE_PLVC_ATTRIBUTE_FIELD_NAME = "referencePLVCAttribute";
+
+    /**
+     * Test if the decoding and convert of the reference possibleLiteralValuesChoice annotation into its java object is
+     * valid.
+     */
+    @Test
+    public void testReferencePLVCAttributeConvert() {
+        try {
+            boolean annotationFound = false;
+            //Retrieve the plvc object
+            Object object = null;
+            //Inspect all the annotation of the field to get the PLVC one
+            Field plvcField = this.getClass().getDeclaredField(REFERENCE_PLVC_ATTRIBUTE_FIELD_NAME);
+            for (Annotation annotation : plvcField.getDeclaredAnnotations()) {
+                //Once the annotation is get, decode it.
+                if (annotation instanceof PossibleLiteralValuesChoiceAttribute) {
+                    annotationFound = true;
+                    PossibleLiteralValuesChoiceAttribute plvcAnnotation = (PossibleLiteralValuesChoiceAttribute) annotation;
+                    object = ObjectAnnotationConverter.annotationToObject(plvcAnnotation);
+                }
+            }
+
+            //If the annotation hasn't been found, the test has failed.
+            if (!annotationFound || object == null) {
+                Assert.fail("Unable to get the annotation '@ValuesAttribute' from the field '" +
+                        REFERENCE_PLVC_ATTRIBUTE_FIELD_NAME + "'.");
+            }
+
+            ///////////////////////////
+            // Tests the PLVC Values //
+            ///////////////////////////
+
+            String reference = "file://file/path";
+            ValuesReference toTest = new ValuesReference();
+            toTest.setReference(reference);
+            toTest.setValue("/path");
+
+            String messageClass = "The parsed value should be a '"+ValuesReference.class.getCanonicalName()+"' instead of '"+
+                    object.getClass().getCanonicalName()+"'.";
+            boolean conditionClass = object instanceof ValuesReference;
+            Assert.assertTrue(messageClass, conditionClass);
+
+            ValuesReference valuesReference = (ValuesReference)object;
+
+            //Test the value
+            String messageValue = "The value is not the one expected (" +
+                    valuesReference.getValue() + " instead of " + toTest.getValue();
+            boolean conditionValue = valuesReference.getValue().equals(toTest.getValue());
+            Assert.assertTrue(messageValue, conditionValue);
+
+            //Test the reference
+            String messageReference = "The reference is not the one expected (" +
+                    valuesReference.getReference() + " instead of " + toTest.getReference();
+            boolean conditionReference = valuesReference.getReference().equals(toTest.getReference());
+            Assert.assertTrue(messageReference, conditionReference);
+
+        } catch (NoSuchFieldException e) {
+            Assert.fail("Unable to get the field '" + REFERENCE_PLVC_ATTRIBUTE_FIELD_NAME + "' from the class '" +
+                    this.getClass().getCanonicalName() + "'.");
+        }
+    }
+
+
+    /***********************
+     * ALLOWED VALUES PLVC *
+     ***********************/
+
+    /** Field containing the plvc annotation. */
+    @PossibleLiteralValuesChoiceAttribute(
+            allowedValues = {@ValuesAttribute(type = ValuesType.RANGE),@ValuesAttribute()}
+    )
+    public Object allowedValuesPLVCAttribute;
+    /** Name of the field containing the allowedValuesPLVCAttribute annotation. */
+    private static final String ALLOWED_VALUES_PLVC_ATTRIBUTE_FIELD_NAME = "allowedValuesPLVCAttribute";
+
+    /**
+     * Test if the decoding and convert of the allowed values possibleLiteralValuesChoice annotation into its java
+     * object is valid.
+     */
+    @Test
+    public void testAllowedValuesPLVCAttributeConvert() {
+        try {
+            boolean annotationFound = false;
+            //Retrieve the plvc object
+            Object object = null;
+            //Inspect all the annotation of the field to get the PLVC one
+            Field plvcField = this.getClass().getDeclaredField(ALLOWED_VALUES_PLVC_ATTRIBUTE_FIELD_NAME);
+            for (Annotation annotation : plvcField.getDeclaredAnnotations()) {
+                //Once the annotation is get, decode it.
+                if (annotation instanceof PossibleLiteralValuesChoiceAttribute) {
+                    annotationFound = true;
+                    PossibleLiteralValuesChoiceAttribute plvcAnnotation = (PossibleLiteralValuesChoiceAttribute) annotation;
+                    object = ObjectAnnotationConverter.annotationToObject(plvcAnnotation);
+                }
+            }
+
+            //If the annotation hasn't been found, the test has failed.
+            if (!annotationFound || object == null) {
+                Assert.fail("Unable to get the annotation '@ValuesAttribute' from the field '" +
+                        ALLOWED_VALUES_PLVC_ATTRIBUTE_FIELD_NAME + "'.");
+            }
+
+            ///////////////////////////
+            // Tests the PLVC Values //
+            ///////////////////////////
+
+            String messageClass = "The parsed value should be a '"+AllowedValues.class.getCanonicalName()+"' instead of '"+
+                    object.getClass().getCanonicalName()+"'.";
+            boolean conditionClass = object instanceof AllowedValues;
+            Assert.assertTrue(messageClass, conditionClass);
+
+            AllowedValues allowedValues = (AllowedValues)object;
+
+            boolean conditionClasses = false;
+            for(Object o : allowedValues.getValueOrRange()){
+                if(!(o instanceof RangeType) && !(o instanceof ValueType)){
+                    conditionClasses = true;
+                }
+            }
+
+
+            String messageClasses = "The allowed values should be an instance of '"+
+                    RangeType.class.getCanonicalName()+"' or '"+ValueType.class.getCanonicalName()+"'.";
+            Assert.assertTrue(messageClasses, conditionClasses);
+
+        } catch (NoSuchFieldException e) {
+            Assert.fail("Unable to get the field '" + ALLOWED_VALUES_PLVC_ATTRIBUTE_FIELD_NAME + "' from the class '" +
+                    this.getClass().getCanonicalName() + "'.");
+        }
+    }
+}

--- a/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/controller/utils/ValuesConvertTest.java
+++ b/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/controller/utils/ValuesConvertTest.java
@@ -56,7 +56,7 @@ public class ValuesConvertTest {
                 Assert.fail("Unable to get the annotation '@ValuesAttribute' from the field '" +
                         FULL_RANGE_ATTRIBUTE_FIELD_NAME + "'.");
             }
-            String messageClass = "The parsed value should be a '"+RangeType.class.getCanonicalName()+"' instance of '"+
+            String messageClass = "The parsed value should be a '"+RangeType.class.getCanonicalName()+"' instead of '"+
                     object.getClass().getCanonicalName()+"'.";
             boolean conditionClass = object instanceof RangeType;
             Assert.assertTrue(messageClass, conditionClass);
@@ -147,7 +147,7 @@ public class ValuesConvertTest {
                 Assert.fail("Unable to get the annotation '@ValuesAttribute' from the field '" +
                         MINIMAL_RANGE_ATTRIBUTE_FIELD_NAME + "'.");
             }
-            String messageClass = "The parsed value should be a '"+RangeType.class.getCanonicalName()+"' instance of '"+
+            String messageClass = "The parsed value should be a '"+RangeType.class.getCanonicalName()+"' instead of '"+
                     object.getClass().getCanonicalName()+"'.";
             boolean conditionClass = object instanceof RangeType;
             Assert.assertTrue(messageClass, conditionClass);
@@ -230,7 +230,7 @@ public class ValuesConvertTest {
                 Assert.fail("Unable to get the annotation '@ValuesAttribute' from the field '" +
                         FULL_VALUE_ATTRIBUTE_FIELD_NAME + "'.");
             }
-            String messageClass = "The parsed value should be a '"+ValueType.class.getCanonicalName()+"' instance of '"+
+            String messageClass = "The parsed value should be a '"+ValueType.class.getCanonicalName()+"' instead of '"+
                     object.getClass().getCanonicalName()+"'.";
             boolean conditionClass = object instanceof ValueType;
             Assert.assertTrue(messageClass, conditionClass);


### PR DESCRIPTION
Add more groovy annotation convert into java object tests :
- LiteralDataDomain
- LiteralDataType
- InputDescriptionType
- PossibleLiteralValuesChoice

Also update the format usage : before when no format were specified for a ComplexData, the other format was set. Now, it is replaced by the text format (text/plain mimetype).