### PR TITLE
ProcessOfferings tests

### DIFF
--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/LocalWpsServiceImplementation.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/LocalWpsServiceImplementation.java
@@ -23,10 +23,8 @@ import net.opengis.ows.v_2_0.*;
 import net.opengis.wps.v_2_0.*;
 import net.opengis.wps.v_2_0.GetCapabilitiesType;
 import net.opengis.wps.v_2_0.DescriptionType;
-import org.apache.commons.collections.ArrayStack;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.output.*;
 import org.h2gis.h2spatialapi.DriverFunction;
 import org.h2gis.h2spatialapi.EmptyProgressVisitor;
 import org.h2gis.h2spatialapi.ProgressVisitor;
@@ -36,7 +34,6 @@ import org.h2gis.utilities.TableLocation;
 import org.orbisgis.corejdbc.*;
 import org.orbisgis.dbjobs.api.DriverFunctionContainer;
 import org.orbisgis.frameworkapi.CoreWorkspace;
-import org.orbisgis.wpsgroovyapi.attributes.LanguageString;
 import org.orbisgis.wpsservice.controller.execution.DataProcessingManager;
 import org.orbisgis.wpsservice.controller.execution.ProcessExecutionListener;
 import org.orbisgis.wpsservice.controller.process.ProcessIdentifier;
@@ -1158,11 +1155,11 @@ public class LocalWpsServiceImplementation implements LocalWpsService, DatabaseP
         LanguageStringType translatedTitle = new LanguageStringType();
         boolean defaultTitleFound = false;
         for(LanguageStringType title : descriptionType.getTitle()){
-            if(title.getLang().equals(language)){
+            if(title.getLang() != null && title.getLang().equals(language)){
                 translatedTitle = title;
                 break;
             }
-            else if(title.getLang().equals(enLanguage)){
+            else if(title.getLang() != null && title.getLang().equals(enLanguage)){
                 translatedTitle = title;
                 defaultTitleFound = true;
             }

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/parser/DataFieldParser.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/parser/DataFieldParser.java
@@ -30,9 +30,9 @@ import org.orbisgis.wpsservice.LocalWpsService;
 import org.orbisgis.wpsservice.controller.utils.FormatFactory;
 import org.orbisgis.wpsservice.controller.utils.ObjectAnnotationConverter;
 import org.orbisgis.wpsservice.model.DataField;
+import org.orbisgis.wpsservice.model.ObjectFactory;
 
 import javax.xml.bind.JAXBElement;
-import javax.xml.namespace.QName;
 import java.lang.reflect.Field;
 import java.net.URI;
 
@@ -55,13 +55,20 @@ public class DataFieldParser implements Parser {
         //Instantiate the DataField object
         DataFieldAttribute dataFieldAttribute = f.getAnnotation(DataFieldAttribute.class);
         Format format = FormatFactory.getFormatFromExtension(FormatFactory.TEXT_EXTENSION);
-        URI dataStoreUri = URI.create(processId + ":input:" + dataFieldAttribute.dataStore());
+        URI dataStoreUri;
+        //If the dataStore attribute is not an URI, autoGenerate one.
+        if(!dataFieldAttribute.dataStore().contains(":")) {
+            dataStoreUri = URI.create(processId + ":input:" + dataFieldAttribute.dataStore());
+        }
+        //else, use it
+        else {
+            dataStoreUri = URI.create(dataFieldAttribute.dataStore());
+        }
         DataField dataField = ObjectAnnotationConverter.annotationToObject(dataFieldAttribute, format, dataStoreUri);
 
         //Instantiate the returned input
         InputDescriptionType input = new InputDescriptionType();
-        QName qname = new QName("http://orbisgis.org", "data_field");
-        JAXBElement<DataField> jaxbElement = new JAXBElement<>(qname, DataField.class, dataField);
+        JAXBElement<DataField> jaxbElement = new ObjectFactory().createDataField(dataField);
         input.setDataDescription(jaxbElement);
 
         ObjectAnnotationConverter.annotationToObject(f.getAnnotation(InputAttribute.class), input);
@@ -81,12 +88,20 @@ public class DataFieldParser implements Parser {
         //Instantiate the DataField object
         DataFieldAttribute dataFieldAttribute = f.getAnnotation(DataFieldAttribute.class);
         Format format = FormatFactory.getFormatFromExtension(FormatFactory.TEXT_EXTENSION);
-        URI dataStoreUri = URI.create(processId + ":output:" + dataFieldAttribute.dataStore());
+        URI dataStoreUri;
+        //If the dataStore attribute is not an URI, autoGenerate one.
+        if(!dataFieldAttribute.dataStore().contains(":")) {
+            dataStoreUri = URI.create(processId + ":output:" + dataFieldAttribute.dataStore());
+        }
+        //else, use it
+        else {
+            dataStoreUri = URI.create(dataFieldAttribute.dataStore());
+        }
         DataField dataField = ObjectAnnotationConverter.annotationToObject(dataFieldAttribute, format, dataStoreUri);
 
         //Instantiate the returned output
-        OutputDescriptionType output = new OutputDescriptionType();QName qname = new QName("http://orbisgis.org", "data_field");
-        JAXBElement<DataField> jaxbElement = new JAXBElement<>(qname, DataField.class, dataField);
+        OutputDescriptionType output = new OutputDescriptionType();
+        JAXBElement<DataField> jaxbElement = new ObjectFactory().createDataField(dataField);
         output.setDataDescription(jaxbElement);
 
         ObjectAnnotationConverter.annotationToObject(f.getAnnotation(DescriptionTypeAttribute.class), output);

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/parser/DataStoreParser.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/parser/DataStoreParser.java
@@ -30,10 +30,10 @@ import org.orbisgis.wpsservice.LocalWpsService;
 import org.orbisgis.wpsservice.controller.utils.FormatFactory;
 import org.orbisgis.wpsservice.controller.utils.ObjectAnnotationConverter;
 import org.orbisgis.wpsservice.model.DataStore;
+import org.orbisgis.wpsservice.model.ObjectFactory;
 import org.slf4j.LoggerFactory;
 
 import javax.xml.bind.JAXBElement;
-import javax.xml.namespace.QName;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
@@ -113,8 +113,7 @@ public class DataStoreParser implements Parser{
         dataStore.setIsFile(isFile);
 
         InputDescriptionType input = new InputDescriptionType();
-        QName qname = new QName("http://orbisgis.org", "DataStore");
-        JAXBElement<DataStore> jaxbElement = new JAXBElement<>(qname, DataStore.class, dataStore);
+        JAXBElement<DataStore> jaxbElement = new ObjectFactory().createDataStore(dataStore);
         input.setDataDescription(jaxbElement);
 
         ObjectAnnotationConverter.annotationToObject(f.getAnnotation(InputAttribute.class), input);
@@ -185,8 +184,7 @@ public class DataStoreParser implements Parser{
         dataStore.setIsFile(isFile);
 
         OutputDescriptionType output = new OutputDescriptionType();
-        QName qname = new QName("http://orbisgis.org", "DataStore");
-        JAXBElement<DataStore> jaxbElement = new JAXBElement<>(qname, DataStore.class, dataStore);
+        JAXBElement<DataStore> jaxbElement = new ObjectFactory().createDataStore(dataStore);
         output.setDataDescription(jaxbElement);
 
         ObjectAnnotationConverter.annotationToObject(f.getAnnotation(DescriptionTypeAttribute.class), output);

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/parser/DataStoreParser.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/parser/DataStoreParser.java
@@ -72,17 +72,21 @@ public class DataStoreParser implements Parser{
         if(dataStoreAttribute.extensions().length!=0) {
             List<String> validFormats = new ArrayList<>();
             for(String extension : dataStoreAttribute.extensions()){
+                boolean validFormat = false;
                 if(extension.equals(FormatFactory.GEOCATALOG_EXTENSION)){
                     isGeocatalog = true;
+                    validFormat = true;
                 }
-                else if(extension.equals(FormatFactory.DATABASE_EXTENSION)){
+                if(extension.equals(FormatFactory.DATABASE_EXTENSION)){
                     isDataBase = true;
+                    validFormat = true;
                 }
-                else if(importableFormat.contains(extension)){
+                if(importableFormat.contains(extension)){
                     isFile = true;
+                    validFormat = true;
                     validFormats.add(extension);
                 }
-                else{
+                if(!validFormat){
                     LoggerFactory.getLogger(DataStoreParser.class).warn("The format '" + extension + "' is not supported");
                 }
             }

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/parser/ParserController.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/controller/parser/ParserController.java
@@ -195,5 +195,29 @@ public class ParserController {
                 }
             }
         }
+        //Link the DataField with its DataStore
+        for(OutputDescriptionType o : p.getOutput()){
+            if(o.getDataDescription().getValue() instanceof DataField){
+                DataField dataField = (DataField)o.getDataDescription().getValue();
+                for(OutputDescriptionType dataStore : p.getOutput()){
+                    if(dataStore.getIdentifier().getValue().equals(dataField.getDataStoreIdentifier().toString())){
+                        ((DataStore)dataStore.getDataDescription().getValue()).addDataField(dataField);
+                    }
+                }
+            }
+        }
+        //Link the FieldValue with its DataField and its DataStore
+        for(OutputDescriptionType o : p.getOutput()){
+            if(o.getDataDescription().getValue() instanceof FieldValue){
+                FieldValue fieldValue = (FieldValue)o.getDataDescription().getValue();
+                for(OutputDescriptionType output : p.getOutput()){
+                    if(output.getIdentifier().getValue().equals(fieldValue.getDataFieldIdentifier().toString())){
+                        DataField dataField = (DataField)output.getDataDescription().getValue();
+                        dataField.addFieldValue(fieldValue);
+                        fieldValue.setDataStoredIdentifier(dataField.getDataStoreIdentifier());
+                    }
+                }
+            }
+        }
     }
 }

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/model/DataField.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/model/DataField.java
@@ -21,7 +21,12 @@ package org.orbisgis.wpsservice.model;
 
 import net.opengis.wps.v_2_0.ComplexDataType;
 import net.opengis.wps.v_2_0.Format;
+import org.jvnet.jaxb2_commons.lang.Equals2;
+import org.jvnet.jaxb2_commons.lang.EqualsStrategy2;
+import org.jvnet.jaxb2_commons.lang.JAXBEqualsStrategy;
+import org.jvnet.jaxb2_commons.locator.ObjectLocator;
 
+import javax.xml.bind.annotation.*;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,19 +35,28 @@ import java.util.List;
  * @author Sylvain PALOMINOS
  **/
 
-public class DataField extends ComplexDataType{
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "DataField", propOrder = {"dataStoreIdentifier", "fieldTypeList",
+        "excludedTypeList", "listFieldValue", "isMultipleField"})
+public class DataField extends ComplexDataType implements Equals2{
 
     /** Identifier of the parent DataStore */
+    @XmlElement(name = "DataStoreId", namespace = "http://orbisgis.org")
     private URI dataStoreIdentifier;
     /** Indicates if the DataField should be reloaded because of a modification of the parent DataStore.*/
+    @XmlTransient
     private boolean isSourceModified = true;
     /** List of type accepted for the field.*/
+    @XmlElement(name = "FieldType", namespace = "http://orbisgis.org")
     private List<DataType> fieldTypeList;
     /** List of type excluded for the field.*/
+    @XmlElement(name = "ExcludedType", namespace = "http://orbisgis.org")
     private List<DataType> excludedTypeList;
     /** List of FieldValue liked to the DataField */
+    @XmlElement(name = "FieldValue", namespace = "http://orbisgis.org")
     private List<FieldValue> listFieldValue;
     /** Indicates if the use can choose more than one field*/
+    @XmlAttribute(name = "isMultipleField", namespace = "http://orbisgis.org")
     private boolean isMultipleField = false;
 
     /**
@@ -57,6 +71,17 @@ public class DataField extends ComplexDataType{
         listFieldValue = new ArrayList<>();
         this.fieldTypeList = fieldTypeList;
         this.dataStoreIdentifier = dataStoreURI;
+    }
+
+    /**
+     * Protected empty constructor used in the ObjectFactory class for JAXB.
+     */
+    protected DataField(){
+        super();
+        fieldTypeList = new ArrayList<>();
+        excludedTypeList = new ArrayList<>();
+        listFieldValue = new ArrayList<>();
+        dataStoreIdentifier = null;
     }
 
     /**
@@ -144,9 +169,40 @@ public class DataField extends ComplexDataType{
 
     /**
      * Sets if the user can select more than one field or not.
-     * @@param True if the user can select more than one field, false otherwise.
+     * @param multipleField True if the user can select more than one field, false otherwise.
      */
     public void setMultipleField(boolean multipleField) {
         isMultipleField = multipleField;
+    }
+
+
+
+    @Override
+    public boolean equals(ObjectLocator thisLocator, ObjectLocator thatLocator, Object object, EqualsStrategy2 strategy) {
+        if ((object == null)||(this.getClass()!= object.getClass())) {
+            return false;
+        }
+        if (this == object) {
+            return true;
+        }
+        if (!super.equals(thisLocator, thatLocator, object, strategy)) {
+            return false;
+        }
+        final DataField that = ((DataField) object);
+        {
+            if( (this.isSourceModified() != that.isSourceModified()) ||
+                    (this.isMultipleField() != that.isMultipleField()) ||
+                    (!this.getDataStoreIdentifier().equals(that.getDataStoreIdentifier())) ||
+                    (!this.getExcludedTypeList().equals(that.getExcludedTypeList())) ||
+                    (!this.getListFieldValue().equals(that.getListFieldValue())) ||
+                    (!this.getFieldTypeList().equals(that.getFieldTypeList())) )
+                return false;
+        }
+        return true;
+    }
+
+    public boolean equals(Object object) {
+        final EqualsStrategy2 strategy = JAXBEqualsStrategy.INSTANCE;
+        return equals(null, null, object, strategy);
     }
 }

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/model/DataStore.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/model/DataStore.java
@@ -21,7 +21,14 @@ package org.orbisgis.wpsservice.model;
 
 import net.opengis.wps.v_2_0.ComplexDataType;
 import net.opengis.wps.v_2_0.Format;
+import org.jvnet.jaxb2_commons.lang.Equals2;
+import org.jvnet.jaxb2_commons.lang.EqualsStrategy2;
+import org.jvnet.jaxb2_commons.lang.JAXBEqualsStrategy;
+import org.jvnet.jaxb2_commons.locator.ObjectLocator;
 
+import javax.xml.bind.annotation.*;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -31,24 +38,31 @@ import java.util.List;
  *
  * @author Sylvain PALOMINOS
  **/
-
-public class DataStore extends ComplexDataType {
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "DataStore", propOrder = {"isSpatial", "isGeocatalog", "isFile", "isDataBase", "listDataField", "isAutoImport"})
+public class DataStore extends ComplexDataType implements Equals2 {
     /**DataStore types.*/
     public static final String DATASTORE_TYPE_GEOCATALOG = "DATASTORE_TYPE_GEOCATALOG";
     public static final String DATASTORE_TYPE_FILE = "DATASTORE_TYPE_FILE";
 
     /** True if the data is spatial, false otherwise **/
+    @XmlAttribute(name = "isSpatial", namespace = "http://orbisgis.org")
     private boolean isSpatial;
     /** True if the data can come from the OrbisGIS geocatalog spatial, false otherwise **/
+    @XmlAttribute(name = "isGeocatalog", namespace = "http://orbisgis.org")
     private boolean isGeocatalog;
     /** True if the data can be a file, false otherwise **/
+    @XmlAttribute(name = "isFile", namespace = "http://orbisgis.org")
     private boolean isFile;
     /** True if the data can come from an external dataBase, false otherwise **/
+    @XmlAttribute(name = "isDataBase", namespace = "http://orbisgis.org")
     private boolean isDataBase;
     /** List of DataField liked to the DataStore */
+    @XmlElement(name = "DataField", namespace = "http://orbisgis.org")
     private List<DataField> listDataField;
     /** True if the toolBox should load the file or just give the file path. */
-    private boolean autoImport;
+    @XmlAttribute(name = "isAutoImport", namespace = "http://orbisgis.org")
+    private boolean isAutoImport;
 
     /**
      * Main constructor
@@ -56,21 +70,24 @@ public class DataStore extends ComplexDataType {
      * @throws MalformedScriptException
      */
     public DataStore(List<Format> formatList) throws MalformedScriptException {
-        setFormat(formatList);
+        super.setFormat(formatList);
         listDataField = new ArrayList<>();
     }
 
     /**
-     * Protected empty constructor used in the ObjectFactory for JAXB.
+     * Protected empty constructor used in the ObjectFactory class for JAXB.
      */
-    protected DataStore(){}
+    protected DataStore(){
+        super();
+        listDataField = new ArrayList<>();
+    }
 
-    public void setAutoImport(boolean autoImport){
-        this.autoImport = autoImport;
+    public void setAutoImport(boolean isAutoImport){
+        this.isAutoImport = isAutoImport;
     }
 
     public boolean isAutoImport(){
-        return autoImport;
+        return isAutoImport;
     }
 
     /**
@@ -173,5 +190,33 @@ public class DataStore extends ComplexDataType {
         uri += dataSource;
         uri += "#"+tableName;
         return URI.create(uri);
+    }
+
+    @Override
+    public boolean equals(ObjectLocator thisLocator, ObjectLocator thatLocator, Object object, EqualsStrategy2 strategy) {
+        if ((object == null)||(this.getClass()!= object.getClass())) {
+            return false;
+        }
+        if (this == object) {
+            return true;
+        }
+        if (!super.equals(thisLocator, thatLocator, object, strategy)) {
+            return false;
+        }
+        final DataStore that = ((DataStore) object);
+        {
+            if( (this.isAutoImport() != that.isAutoImport()) ||
+                    (this.isDataBase() != that.isDataBase()) ||
+                    (this.isFile() != that.isFile()) ||
+                    (this.isGeocatalog() != that.isGeocatalog()) ||
+                    (this.isSpatial() != that.isSpatial()) )
+                return false;
+        }
+        return true;
+    }
+
+    public boolean equals(Object object) {
+        final EqualsStrategy2 strategy = JAXBEqualsStrategy.INSTANCE;
+        return equals(null, null, object, strategy);
     }
 }

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/model/ObjectFactory.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/model/ObjectFactory.java
@@ -33,18 +33,19 @@ public class ObjectFactory {
      * Create an instance of {@link DataStore }
      *
      */
-    public DataStore createProcessDescriptionType() {
-        return new DataStore();
-    }
+    public DataStore createDataStore() { return new DataStore(); }
 
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link DataStore }{@code >}}
      *
      */
-    @XmlElementDecl(namespace = "http://orbisgis.org", name = "DataStore")
-    public JAXBElement<DataStore> createProcess(DataStore value) {
-        return new JAXBElement<DataStore>(_DataStore_QNAME, DataStore.class, null, value);
+    @XmlElementDecl(namespace="http://orbisgis.org",
+            name="DataStore",
+            substitutionHeadNamespace="http://www.opengis.net/wps/2.0",
+            substitutionHeadName="DataDescription")
+    public JAXBElement<DataStore> createDataStore(DataStore dataStore) {
+        return new JAXBElement<DataStore>(new QName("http://orbisgis.org", "DataStore"), DataStore.class, dataStore);
     }
 
 }

--- a/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/model/ObjectFactory.java
+++ b/bundles/wps-service/src/main/java/org/orbisgis/wpsservice/model/ObjectFactory.java
@@ -3,7 +3,6 @@ package org.orbisgis.wpsservice.model;
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.annotation.XmlElementDecl;
 import javax.xml.bind.annotation.XmlRegistry;
-import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
 
 
@@ -21,6 +20,7 @@ import javax.xml.namespace.QName;
 public class ObjectFactory {
 
     private final static QName _DataStore_QNAME = new QName("http://orbisgis.org", "DataStore");
+    private final static QName _DataField_QNAME = new QName("http://orbisgis.org", "DataField");
 
     /**
      * Create a new ObjectFactory that can be used to create new instances of schema derived classes for package: net.opengis.wps.v_2_0
@@ -45,7 +45,24 @@ public class ObjectFactory {
             substitutionHeadNamespace="http://www.opengis.net/wps/2.0",
             substitutionHeadName="DataDescription")
     public JAXBElement<DataStore> createDataStore(DataStore dataStore) {
-        return new JAXBElement<DataStore>(new QName("http://orbisgis.org", "DataStore"), DataStore.class, dataStore);
+        return new JAXBElement<>(_DataStore_QNAME, DataStore.class, dataStore);
     }
 
+    /**
+     * Create an instance of {@link DataField }
+     *
+     */
+    public DataField createDataField() { return new DataField(); }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link DataField }{@code >}}
+     *
+     */
+    @XmlElementDecl(namespace="http://orbisgis.org",
+            name="DataField",
+            substitutionHeadNamespace="http://www.opengis.net/wps/2.0",
+            substitutionHeadName="DataDescription")
+    public JAXBElement<DataField> createDataField(DataField dataField) {
+        return new JAXBElement<>(_DataField_QNAME, DataField.class, dataField);
+    }
 }

--- a/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/DescribeProcessScriptTest.java
+++ b/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/DescribeProcessScriptTest.java
@@ -81,12 +81,6 @@ public class DescribeProcessScriptTest {
         ByteArrayOutputStream xml = (ByteArrayOutputStream)wpsService.callOperation(in);
         //Get back the result of the DescribeProcess request as a BufferReader
         InputStream resultXml = new ByteArrayInputStream(xml.toByteArray());
-        BufferedReader br = new BufferedReader(new InputStreamReader(resultXml));
-        String line;
-        while((line = br.readLine()) != null){
-            System.out.println(line);
-        }
-        resultXml.reset();
         //Unmarshall the result and check that the object is the same as the resource unmashalled xml.
         Unmarshaller unmarshaller = JaxbContainer.JAXBCONTEXT.createUnmarshaller();
         Object resultObject = unmarshaller.unmarshal(resultXml);

--- a/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/DescribeProcessScriptTest.java
+++ b/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/DescribeProcessScriptTest.java
@@ -5,14 +5,12 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import javax.xml.bind.*;
 
 import net.opengis.ows.v_2_0.CodeType;
-import net.opengis.wps.v_2_0.DescribeProcess;
+import net.opengis.wps.v_2_0.*;
 import org.junit.Assert;
 import org.junit.Test;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.Unmarshaller;
 
 /**
  * This test class perform tests about groovy wps scripts.
@@ -27,7 +25,7 @@ public class DescribeProcessScriptTest {
      * Test the DataStore script DescribeProcess request.
      */
     @Test
-    public void testDataStoreScript(){
+    public void testDataStoreScript() throws JAXBException, IOException {
         //Start the wpsService
         initWpsService();
         //Build the DescribeProcess object
@@ -39,36 +37,23 @@ public class DescribeProcessScriptTest {
         identifierList.add(dataStoreId);
         describeProcess.setIdentifier(identifierList);
         //Marshall the DescribeProcess object into an OutputStream
-        try {
-            Marshaller marshaller = JaxbContainer.JAXBCONTEXT.createMarshaller();
-            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            marshaller.marshal(describeProcess, out);
-            //Write the OutputStream content into an Input stream before sending it to the wpsService
-            InputStream in = new DataInputStream(new ByteArrayInputStream(out.toByteArray()));
-            ByteArrayOutputStream xml = (ByteArrayOutputStream)wpsService.callOperation(in);
-            //Get back the result of the DescribeProcess request as a BufferReader
-            InputStream resultXml = new ByteArrayInputStream(xml.toByteArray());
-            //Unmarshall the result and check that the object is the same as the resource unmashalled xml.
-            Unmarshaller unmarshaller = JaxbContainer.JAXBCONTEXT.createUnmarshaller();
-            Object resultObject = unmarshaller.unmarshal(resultXml);
-            File f = new File(this.getClass().getResource("DataStoreProcessOfferings.xml").getFile());
-            Object ressourceObject = unmarshaller.unmarshal(f);
-            String message = "Error on unmarshalling the WpsService answer, the object is not the one expected.\n\n";
+        Marshaller marshaller = JaxbContainer.JAXBCONTEXT.createMarshaller();
+        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        marshaller.marshal(describeProcess, out);
+        //Write the OutputStream content into an Input stream before sending it to the wpsService
+        InputStream in = new DataInputStream(new ByteArrayInputStream(out.toByteArray()));
+        ByteArrayOutputStream xml = (ByteArrayOutputStream)wpsService.callOperation(in);
+        //Get back the result of the DescribeProcess request as a BufferReader
+        InputStream resultXml = new ByteArrayInputStream(xml.toByteArray());
+        //Unmarshall the result and check that the object is the same as the resource unmashalled xml.
+        Unmarshaller unmarshaller = JaxbContainer.JAXBCONTEXT.createUnmarshaller();
+        Object resultObject = unmarshaller.unmarshal(resultXml);
+        File f = new File(this.getClass().getResource("DataStoreProcessOfferings.xml").getFile());
+        Object ressourceObject = unmarshaller.unmarshal(f);
 
-            //Get the result xml
-            resultXml.reset();
-            BufferedReader result = new BufferedReader(new InputStreamReader(resultXml));
-            String responseLine;
-            while ((responseLine = result.readLine()) != null) {
-                message+=responseLine+"\n";
-            }
-
-            Assert.assertTrue(message, ressourceObject.equals(resultObject));
-        } catch (JAXBException | IOException e) {
-            Assert.fail(e.getLocalizedMessage());
-        }
-
+        String message = "Error on unmarshalling the WpsService answer, the object is not the one expected.\n\n";
+        Assert.assertTrue(message, ressourceObject.equals(resultObject));
     }
 
     /**

--- a/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/DescribeProcessScriptTest.java
+++ b/bundles/wps-service/src/test/java/org/orbisgis/wpsservice/DescribeProcessScriptTest.java
@@ -57,6 +57,47 @@ public class DescribeProcessScriptTest {
     }
 
     /**
+     * Test the DataField script DescribeProcess request.
+     */
+    @Test
+    public void testDataFieldScript() throws JAXBException, IOException {
+        //Start the wpsService
+        initWpsService();
+        //Build the DescribeProcess object
+        DescribeProcess describeProcess = new DescribeProcess();
+        describeProcess.setLang("fr");
+        List<CodeType> identifierList = new ArrayList<>();
+        CodeType dataStoreId = new CodeType();
+        dataStoreId.setValue("orbisgis:test:datafield");
+        identifierList.add(dataStoreId);
+        describeProcess.setIdentifier(identifierList);
+        //Marshall the DescribeProcess object into an OutputStream
+        Marshaller marshaller = JaxbContainer.JAXBCONTEXT.createMarshaller();
+        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        marshaller.marshal(describeProcess, out);
+        //Write the OutputStream content into an Input stream before sending it to the wpsService
+        InputStream in = new DataInputStream(new ByteArrayInputStream(out.toByteArray()));
+        ByteArrayOutputStream xml = (ByteArrayOutputStream)wpsService.callOperation(in);
+        //Get back the result of the DescribeProcess request as a BufferReader
+        InputStream resultXml = new ByteArrayInputStream(xml.toByteArray());
+        BufferedReader br = new BufferedReader(new InputStreamReader(resultXml));
+        String line;
+        while((line = br.readLine()) != null){
+            System.out.println(line);
+        }
+        resultXml.reset();
+        //Unmarshall the result and check that the object is the same as the resource unmashalled xml.
+        Unmarshaller unmarshaller = JaxbContainer.JAXBCONTEXT.createUnmarshaller();
+        Object resultObject = unmarshaller.unmarshal(resultXml);
+        File f = new File(this.getClass().getResource("DataFieldProcessOfferings.xml").getFile());
+        Object ressourceObject = unmarshaller.unmarshal(f);
+
+        String message = "Error on unmarshalling the WpsService answer, the object is not the one expected.\n\n";
+        Assert.assertTrue(message, ressourceObject.equals(resultObject));
+    }
+
+    /**
      * Initialise a wpsService to test the scripts.
      * The initialised wpsService can't execute the processes.
      */
@@ -68,6 +109,11 @@ public class DescribeProcessScriptTest {
             //Try to load the groovy scripts
             try {
                 URL url = this.getClass().getResource("DataStore.groovy");
+                if (url != null) {
+                    File f = new File(url.toURI());
+                    localWpsService.addLocalScript(f, null, false);
+                }
+                url = this.getClass().getResource("DataField.groovy");
                 if (url != null) {
                     File f = new File(url.toURI());
                     localWpsService.addLocalScript(f, null, false);

--- a/bundles/wps-service/src/test/resources/org/orbisgis/wpsservice/DataField.groovy
+++ b/bundles/wps-service/src/test/resources/org/orbisgis/wpsservice/DataField.groovy
@@ -1,0 +1,129 @@
+package org.orbisgis.wpsservice
+
+import org.orbisgis.wpsgroovyapi.attributes.Keyword
+import org.orbisgis.wpsgroovyapi.attributes.LanguageString
+import org.orbisgis.wpsgroovyapi.attributes.MetadataAttribute
+import org.orbisgis.wpsgroovyapi.input.DataFieldInput
+import org.orbisgis.wpsgroovyapi.input.DataStoreInput
+import org.orbisgis.wpsgroovyapi.output.DataFieldOutput
+import org.orbisgis.wpsgroovyapi.output.DataStoreOutput
+import org.orbisgis.wpsgroovyapi.process.Process
+
+/********************/
+/** Process method **/
+/********************/
+
+/**
+ * Test script for the DataField
+ * @author Sylvain PALOMINOS
+ */
+@Process(title = "DataFieldTest",
+        traducedTitles = [
+                @LanguageString(value = "DataField test", lang = "en"),
+                @LanguageString(value = "Test du DataField", lang = "fr")
+        ],
+        resume = "Test script using the DataField ComplexData.",
+        traducedResumes = [
+                @LanguageString(value = "Test script using the DataField ComplexData.", lang = "en"),
+                @LanguageString(value = "Scripts test pour l'usage du DataField DataField.", lang = "fr")
+        ],
+        keywords = ["test", "script", "wps"],
+        traducedKeywords = [
+                @Keyword(traducedKeywords = [
+                        @LanguageString(value = "test", lang = "en"),
+                        @LanguageString(value = "test", lang = "fr")
+                ]),
+                @Keyword(traducedKeywords = [
+                        @LanguageString(value = "script", lang = "en"),
+                        @LanguageString(value = "scripte", lang = "fr")
+                ]),
+                @Keyword(traducedKeywords = [
+                        @LanguageString(value = "wps", lang = "en"),
+                        @LanguageString(value = "wps", lang = "fr")
+                ])
+        ],
+        identifier = "orbisgis:test:datafield",
+        metadata = [
+                @MetadataAttribute(title = "metadata", role = "website", href = "http://orbisgis.org/")
+        ]
+)
+def processing() {
+    dataFieldOutput = inputDataField;
+}
+
+
+/****************/
+/** INPUT Data **/
+/****************/
+
+@DataStoreInput(title = "DataStore for the DataField",
+        identifier = "orbisgis:test:datastore:input")
+String dataStoreInput
+
+/** This DataField is the input data source. */
+@DataFieldInput(
+        title = "Input DataField",
+        traducedTitles = [
+                @LanguageString(value = "Input DataField", lang = "en"),
+                @LanguageString(value = "Entrée DataField", lang = "fr")
+        ],
+        resume = "A DataField input.",
+        traducedResumes = [
+                @LanguageString(value = "A DataField input.", lang = "en"),
+                @LanguageString(value = "Une entrée DataField.", lang = "fr")
+        ],
+        keywords = ["input"],
+        traducedKeywords = [
+                @Keyword(traducedKeywords = [
+                        @LanguageString(value = "input", lang = "en"),
+                        @LanguageString(value = "entrée", lang = "fr")
+                ])
+        ],
+        dataStore = "orbisgis:test:datastore:input",
+        excludedTypes = ["BOOLEAN"],
+        minOccurs = 0,
+        maxOccurs = 2,
+        identifier = "orbisgis:test:datafield:input",
+        metadata = [
+                @MetadataAttribute(title = "metadata", role = "website", href = "http://orbisgis.org/")
+        ]
+        )
+String inputDataField
+
+/*****************/
+/** OUTPUT Data **/
+/*****************/
+
+@DataStoreOutput(title = "DataStore for the DataField",
+        identifier = "orbisgis:test:datastore:output")
+String dataStoreOutput
+
+/** This DataField is the output data source. */
+@DataFieldOutput(
+        title="Output DataField",
+        traducedTitles = [
+                @LanguageString(value = "Output DataField", lang = "en"),
+                @LanguageString(value = "Sortie DataField", lang = "fr")
+        ],
+        resume="A DataField output",
+        traducedResumes = [
+                @LanguageString(value = "A DataField output.", lang = "en"),
+                @LanguageString(value = "Une sortie DataField.", lang = "fr")
+        ],
+        keywords = ["output"],
+        traducedKeywords = [
+                @Keyword(traducedKeywords = [
+                        @LanguageString(value = "output", lang = "en"),
+                        @LanguageString(value = "sortie", lang = "fr")
+                ])
+        ],
+        dataStore = "orbisgis:test:datastore:output",
+        fieldTypes = ["GEOMETRY", "NUMBER"],
+        isMultipleField = true,
+        identifier = "orbisgis:test:datafield:output",
+        metadata = [
+                @MetadataAttribute(title = "metadata", role = "website", href = "http://orbisgis.org/")
+        ]
+)
+String dataFieldOutput
+

--- a/bundles/wps-service/src/test/resources/org/orbisgis/wpsservice/DataFieldProcessOfferings.xml
+++ b/bundles/wps-service/src/test/resources/org/orbisgis/wpsservice/DataFieldProcessOfferings.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ns3:ProcessOfferings xmlns:ns1="http://www.opengis.net/ows/2.0" xmlns:ns2="http://www.w3.org/1999/xlink" xmlns:ns3="http://www.opengis.net/wps/2.0" xmlns:ns5="http://orbisgis.org">
+    <ns3:ProcessOffering jobControlOptions="async-execute sync-execute">
+        <ns3:Process xml:lang="fr">
+            <ns1:Title xml:lang="fr">Test du DataField</ns1:Title>
+            <ns1:Abstract xml:lang="fr">Scripts test pour l'usage du DataField DataField.</ns1:Abstract>
+            <ns1:Keywords>
+                <ns1:Keyword xml:lang="fr">test</ns1:Keyword>
+                <ns1:Keyword xml:lang="fr">scripte</ns1:Keyword>
+                <ns1:Keyword xml:lang="fr">wps</ns1:Keyword>
+            </ns1:Keywords>
+            <ns1:Identifier>orbisgis:test:datafield</ns1:Identifier>
+            <ns1:Metadata ns2:type="simple" ns2:href="http://orbisgis.org/" ns2:role="website" ns2:title="metadata"/>
+            <ns3:Input minOccurs="1" maxOccurs="1">
+                <ns1:Title>DataStore for the DataField</ns1:Title>
+                <ns1:Abstract/>
+                <ns1:Keywords/>
+                <ns1:Identifier>orbisgis:test:datastore:input</ns1:Identifier>
+                <ns5:DataStore ns5:isSpatial="false" ns5:isGeocatalog="true" ns5:isFile="true" ns5:isDataBase="true" ns5:isAutoImport="true">
+                    <ns3:Format mimeType="text/plain" encoding="simple" schema="" default="true"/>
+                    <ns5:DataField ns5:isMultipleField="false">
+                        <ns3:Format mimeType="text/plain" encoding="simple" schema="" default="true"/>
+                        <ns5:DataStoreId>orbisgis:test:datastore:input</ns5:DataStoreId>
+                        <ns5:ExcludedType>BOOLEAN</ns5:ExcludedType>
+                    </ns5:DataField>
+                </ns5:DataStore>
+            </ns3:Input>
+            <ns3:Input minOccurs="0" maxOccurs="2">
+                <ns1:Title xml:lang="fr">Entrée DataField</ns1:Title>
+                <ns1:Abstract xml:lang="fr">Une entrée DataField.</ns1:Abstract>
+                <ns1:Keywords>
+                    <ns1:Keyword xml:lang="fr">entrée</ns1:Keyword>
+                </ns1:Keywords>
+                <ns1:Identifier>orbisgis:test:datafield:input</ns1:Identifier>
+                <ns1:Metadata ns2:type="simple" ns2:href="http://orbisgis.org/" ns2:role="website" ns2:title="metadata"/>
+                <ns5:DataField ns5:isMultipleField="false">
+                    <ns3:Format mimeType="text/plain" encoding="simple" schema="" default="true"/>
+                    <ns5:DataStoreId>orbisgis:test:datastore:input</ns5:DataStoreId>
+                    <ns5:ExcludedType>BOOLEAN</ns5:ExcludedType>
+                </ns5:DataField>
+            </ns3:Input>
+            <ns3:Output>
+                <ns1:Title>DataStore for the DataField</ns1:Title>
+                <ns1:Abstract/>
+                <ns1:Keywords/>
+                <ns1:Identifier>orbisgis:test:datastore:output</ns1:Identifier>
+                <ns5:DataStore ns5:isSpatial="false" ns5:isGeocatalog="true" ns5:isFile="true" ns5:isDataBase="true" ns5:isAutoImport="true">
+                    <ns3:Format mimeType="text/plain" encoding="simple" schema="" default="true"/>
+                    <ns5:DataField ns5:isMultipleField="true">
+                        <ns3:Format mimeType="text/plain" encoding="simple" schema="" default="true"/>
+                        <ns5:DataStoreId>orbisgis:test:datastore:output</ns5:DataStoreId>
+                        <ns5:FieldType>GEOMETRY</ns5:FieldType>
+                        <ns5:FieldType>NUMBER</ns5:FieldType>
+                    </ns5:DataField>
+                </ns5:DataStore>
+            </ns3:Output>
+            <ns3:Output>
+                <ns1:Title xml:lang="fr">Sortie DataField</ns1:Title>
+                <ns1:Abstract xml:lang="fr">Une sortie DataField.</ns1:Abstract>
+                <ns1:Keywords>
+                    <ns1:Keyword xml:lang="fr">sortie</ns1:Keyword>
+                </ns1:Keywords>
+                <ns1:Identifier>orbisgis:test:datafield:output</ns1:Identifier>
+                <ns1:Metadata ns2:type="simple" ns2:href="http://orbisgis.org/" ns2:role="website" ns2:title="metadata"/>
+                <ns5:DataField ns5:isMultipleField="true">
+                    <ns3:Format mimeType="text/plain" encoding="simple" schema="" default="true"/>
+                    <ns5:DataStoreId>orbisgis:test:datastore:output</ns5:DataStoreId>
+                    <ns5:FieldType>GEOMETRY</ns5:FieldType>
+                    <ns5:FieldType>NUMBER</ns5:FieldType>
+                </ns5:DataField>
+            </ns3:Output>
+        </ns3:Process>
+    </ns3:ProcessOffering>
+</ns3:ProcessOfferings>

--- a/bundles/wps-service/src/test/resources/org/orbisgis/wpsservice/DataStoreProcessOfferings.xml
+++ b/bundles/wps-service/src/test/resources/org/orbisgis/wpsservice/DataStoreProcessOfferings.xml
@@ -1,4 +1,4 @@
-<!-- This xml is used to test the DescribeProcess WPS operation result on the DataStore.groovy script. -->
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <ns4:ProcessOfferings xmlns:ns2="http://www.w3.org/1999/xlink" xmlns:ns3="http://www.opengis.net/ows/2.0" xmlns:ns4="http://www.opengis.net/wps/2.0" xmlns:ns5="http://orbisgis.org">
     <ns4:ProcessOffering jobControlOptions="async-execute sync-execute">
         <ns4:Process xml:lang="fr">
@@ -19,13 +19,8 @@
                 </ns3:Keywords>
                 <ns3:Identifier>orbisgis:test:datastore:input</ns3:Identifier>
                 <ns3:Metadata ns2:type="simple" ns2:href="http://orbisgis.org/" ns2:role="website" ns2:title="metadata"/>
-                <ns5:DataStore>
-                    <ns4:Format mimeType="text/plain" encoding="simple" schema="" default="true"/>
-                    <isSpatial>true</isSpatial>
-                    <isGeocatalog>true</isGeocatalog>
-                    <isFile>false</isFile>
-                    <isDataBase>false</isDataBase>
-                    <autoImport>false</autoImport>
+                <ns5:DataStore ns5:isSpatial="true" ns5:isGeocatalog="true" ns5:isFile="false" ns5:isDataBase="false" ns5:isAutoImport="false">
+                    <ns4:Format mimeType="text/plain" encoding="simple" schema="" default = "true"/>
                 </ns5:DataStore>
             </ns4:Input>
             <ns4:Output>
@@ -36,13 +31,8 @@
                 </ns3:Keywords>
                 <ns3:Identifier>orbisgis:test:datastore:output</ns3:Identifier>
                 <ns3:Metadata ns2:type="simple" ns2:href="http://orbisgis.org/" ns2:role="website" ns2:title="metadata"/>
-                <ns5:DataStore>
+                <ns5:DataStore ns5:isSpatial="false" ns5:isGeocatalog="true" ns5:isFile="false" ns5:isDataBase="false" ns5:isAutoImport="true">
                     <ns4:Format mimeType="text/plain" encoding="simple" schema="" default="true"/>
-                    <isSpatial>false</isSpatial>
-                    <isGeocatalog>true</isGeocatalog>
-                    <isFile>false</isFile>
-                    <isDataBase>false</isDataBase>
-                    <autoImport>true</autoImport>
                 </ns5:DataStore>
             </ns4:Output>
         </ns4:Process>


### PR DESCRIPTION
Updates the DataStore and DataField classes with the JAXB annotations to work with the marshall/unmarshall.
Implements the tests for the DescribeProcess request answer (ProcessOfferings  with a script containing DataStores and an other containing DataFields.
Few fixes on other classes.