### PR TITLE
Improve the lanch .bat and .sh files.

### DIFF
--- a/orbisgis-dist/src/bin/zip/orbisgis.sh
+++ b/orbisgis-dist/src/bin/zip/orbisgis.sh
@@ -28,5 +28,20 @@
 # info_at_ orbisgis.org
 #
 
-cd $(dirname "$0")
-java -Xmx1024M -jar orbisgis.jar $*
+# Total memory in KB
+totalMemKB=$(awk '/MemTotal:/ { print $2 }' /proc/meminfo)
+
+# If unable to retrieve the memory, run orbisgis with 1024M
+if [ -z "$totalMemKB" ]; then
+	cd $(dirname "$0")
+	java -Xmx1024m -jar orbisgis.jar $*
+# Else, uses a percentage of the physical memory
+else
+	# Percentage of memory to use for Java heap
+	usagePercent=30
+
+	let heapKB=$totalMemKB*$usagePercent/100
+	let heapMB=$heapKB/1024
+	cd $(dirname "$0")
+	java -Xmx${heapMB}m -jar orbisgis.jar $*
+fi

--- a/orbisgis-dist/src/bin/zip/orbisgis_safemode.sh
+++ b/orbisgis-dist/src/bin/zip/orbisgis_safemode.sh
@@ -28,5 +28,20 @@
 # info_at_ orbisgis.org
 #
 
-cd $(dirname "$0")
-java -Xmx1024M -jar orbisgis.jar $* --nofailmode
+# Total memory in KB
+totalMemKB=$(awk '/MemTotal:/ { print $2 }' /proc/meminfo)
+
+# If unable to retrieve the memory, run orbisgis with 1024M
+if [ -z "$totalMemKB" ]; then
+	cd $(dirname "$0")
+	java -Xmx1024m -jar orbisgis.jar $* --nofailmode
+# Else, uses a percentage of the physical memory
+else
+	# Percentage of memory to use for Java heap
+	usagePercent=30
+
+	let heapKB=$totalMemKB*$usagePercent/100
+	let heapMB=$heapKB/1024
+	cd $(dirname "$0")
+	java -Xmx${heapMB}m -jar orbisgis.jar $* --nofailmode
+fi

--- a/orbisgis-dist/src/bin/zip/orbisgis_windows.bat
+++ b/orbisgis-dist/src/bin/zip/orbisgis_windows.bat
@@ -1,3 +1,18 @@
+@ECHO OFF
+
+SET PERCENT= 30
+set MEM=0
+
+FOR /F "delims= skip=1" %%i IN ('wmic computersystem get TotalPhysicalMemory') DO (
+	set MEM=%%i
+	goto STOP
+)
+:STOP
+IF %MEM% GTR 0 (
+	SET /A MEM /= 1024*1024*100/PERCENT
+) ELSE (
+	SET MEM=1024
+)
 cd /d %~dp0
-java -jar -Xmx1024M -jar orbisgis.jar
+java -jar -Xmx%mem%M -jar orbisgis.jar
 pause

--- a/orbisgis-dist/src/bin/zip/orbisgis_windows_safemode.bat
+++ b/orbisgis-dist/src/bin/zip/orbisgis_windows_safemode.bat
@@ -1,3 +1,18 @@
+@ECHO OFF
+
+SET PERCENT= 30
+set MEM=0
+
+FOR /F "delims= skip=1" %%i IN ('wmic computersystem get TotalPhysicalMemory') DO (
+	set MEM=%%i
+	goto STOP
+)
+:STOP
+IF %MEM% GTR 0 (
+	SET /A MEM /= 1024*1024*100/PERCENT
+) ELSE (
+	SET MEM=1024
+)
 cd /d %~dp0
-java -jar -Xmx1024M -jar orbisgis.jar --nofailmode
+java -jar -Xmx%mem%M -jar orbisgis.jar --nofailmode
 pause


### PR DESCRIPTION
Improve the lanch .bat and .sh files to take if possible a percentage of the physical memory for the java heap space. (issue #759)