### PR TITLE
OrbisGIS uses the SNAPSHOT OBR if the version is a sanpshot one.

### DIFF
--- a/bundles/orbisgis-omanager-plugin/src/main/java/org/orbisgis/omanager/plugin/impl/ManagerMenuFactory.java
+++ b/bundles/orbisgis-omanager-plugin/src/main/java/org/orbisgis/omanager/plugin/impl/ManagerMenuFactory.java
@@ -73,6 +73,8 @@ public class ManagerMenuFactory implements MainFrameAction {
     public static final String MENU_MANAGE_PLUGINS = "A_MANAGE_PLUGINS";
     private static final String OSGI_REPOSITORY_FILENAME = "repositories.properties";
     private final URI ORBISGIS_OSGI_REPOSITORY = URI.create("http://plugins.orbisgis.org/.meta/obr.xml");
+    private final URI ORBISGIS_OSGI_REPOSITORY_SNAPSHOT =
+            URI.create("http://nexus.orbisgis.org/content/shadows/obr-snapshot/.meta/obr.xml");
     private static final I18n I18N = I18nFactory.getI18n(ManagerMenuFactory.class);
     private MainDialog mainPanel;
     private MainWindow target; // There is only one main window in the application, it can be stored here.
@@ -142,6 +144,7 @@ public class ManagerMenuFactory implements MainFrameAction {
         if(!addingRepositories.getAndSet(true)) {
             // Read repositories
             Set<URI> obrRepositories = new HashSet<>();
+            obrRepositories.add(ORBISGIS_OSGI_REPOSITORY_SNAPSHOT);
             obrRepositories.add(ORBISGIS_OSGI_REPOSITORY);
             readRepositoryListFile(obrRepositories, bc.getDataFile(OSGI_REPOSITORY_FILENAME));
             RegisterSavedRepositories process = new RegisterSavedRepositories(obrRepositories,repositoryAdmin,addingRepositories);

--- a/framework/src/main/java/org/orbisgis/framework/Main.java
+++ b/framework/src/main/java/org/orbisgis/framework/Main.java
@@ -64,6 +64,9 @@ final class Main {
     private static final int BUNDLE_STABILITY_TIMEOUT = 3000;
     private static final int SAFE_MODE_COUNTDOWN_DELETE = 5000;
     private static final Logger LOGGER = new Logger();
+    private static Version version;
+    private static final String OBR_REPOSITORY_URL = "obr.repository.url";
+    private static final String OBR_REPOSITORY_SNAPSHOT_URL = "obr.repository.snapshot.url";
 
     //Minimum supported java version
     public static final char MIN_JAVA_VERSION = '7';
@@ -108,7 +111,7 @@ final class Main {
             JOptionPane.showMessageDialog(null, I18N.tr("OrbisGIS needs at least a java 1.7+"));
         } else {
             // Fetch application version
-            Version version = new Version(1, 0, 0);
+            version = new Version(1, 0, 0);
             try (InputStream fs = Main.class.getResourceAsStream("version.txt")) {
                 String versionTxt = IOUtils.readLines(fs).get(0);
                 version = new Version(versionTxt.replace("-", "."));
@@ -186,6 +189,16 @@ final class Main {
         {
             System.err.println("No " + org.apache.felix.main.Main.CONFIG_PROPERTIES_FILE_VALUE + " found.");
             configProps = new HashMap<>();
+        }
+
+        //If OrbisGIS is in a SNAPSHOT version, uses the release and snapshot orb.
+        //Else only uses the release one.
+        if(configProps.containsKey(OBR_REPOSITORY_URL) && configProps.containsKey(OBR_REPOSITORY_SNAPSHOT_URL)) {
+            if (version.getQualifier().equals("SNAPSHOT")) {
+                configProps.remove(OBR_REPOSITORY_URL);
+                configProps.put(OBR_REPOSITORY_URL, configProps.get(OBR_REPOSITORY_SNAPSHOT_URL));
+            }
+            configProps.remove(OBR_REPOSITORY_SNAPSHOT_URL);
         }
 
         // Copy framework properties from the system properties.

--- a/orbisgis-dist/src/conf/config.properties
+++ b/orbisgis-dist/src/conf/config.properties
@@ -40,5 +40,5 @@ org.ops4j.pax.logging.skipJUL=True
 #org.osgi.framework.system.packages.ignore=org.w3c.dom,org.w3c.dom.traversal,org.w3c.dom.ranges,org.w3c.dom.ls
 org.osgi.service.http.port=8080
 obr.repository.url=http://plugins.orbisgis.org/.meta/obr.xml
-# For both release and experimental plugins uncomment
-#obr.repository.url=http://plugins.orbisgis.org/.meta/obr.xml http://nexus.orbisgis.org/content/shadows/obr-snapshot/.meta/obr.xml
+# release and experimental plugins
+obr.repository.snapshot.url=http://plugins.orbisgis.org/.meta/obr.xml http://nexus.orbisgis.org/content/shadows/obr-snapshot/.meta/obr.xml


### PR DESCRIPTION
OrbisGIS uses the SNAPSHOT OBR if the version is a sanpshot one.