### PR TITLE
Fixes the process editors.

### DIFF
--- a/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/WpsClientImpl.java
+++ b/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/WpsClientImpl.java
@@ -53,6 +53,7 @@ import org.orbisgis.sif.docking.DockingManager;
 import org.orbisgis.sif.docking.DockingPanel;
 import org.orbisgis.sif.docking.DockingPanelParameters;
 import org.orbisgis.sif.edition.EditorDockable;
+import org.orbisgis.sif.edition.EditorManager;
 import org.orbisgis.wpsclient.api.InternalWpsClient;
 import org.orbisgis.wpsclient.api.WpsClient;
 import org.orbisgis.wpsclient.api.utils.ProcessExecutionType;
@@ -141,7 +142,7 @@ public class WpsClientImpl implements DockingPanel, InternalWpsClient, PropertyC
 
 
     /***************************/
-    /** WpsClientImpl mathods **/
+    /** WpsClientImpl methods **/
     /***************************/
 
     /** OSGI active/deactivate, set/unset methods **/
@@ -500,13 +501,11 @@ public class WpsClientImpl implements DockingPanel, InternalWpsClient, PropertyC
         job.addPropertyChangeListener(this);
         job.addPropertyChangeListener(lee);
         //First test if the ProcessEditor has not been already deleted.
-        if(dockingManager.getPanels().contains(pe)) {
-            dockingManager.removeDockingPanel(pe.getDockingParameters().getName());
-        }
         //Test if the ProcessEditor is in the editor list before removing it.
         if(openEditorList.contains(pe)) {
             openEditorList.remove(pe);
         }
+        dockingManager.removeDockingPanel(pe.getDockingParameters().getName());
     }
 
     /**
@@ -642,7 +641,8 @@ public class WpsClientImpl implements DockingPanel, InternalWpsClient, PropertyC
             joinedDefaultValuesMap.putAll(defaultValuesMap);
         }
         ProcessEditableElement processEditableElement = new ProcessEditableElement(listProcess.get(0), joinedDefaultValuesMap);
-        ProcessEditor pe = new ProcessEditor(this, processEditableElement, type);
+        processEditableElement.setProcessExecutionType(type);
+        ProcessEditor pe = new ProcessEditor(this, processEditableElement);
         //Find if there is already a ProcessEditor open with the same process.
         //If not, add the new one.
         boolean alreadyOpen = false;

--- a/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/dataui/RawDataUI.java
+++ b/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/dataui/RawDataUI.java
@@ -107,14 +107,17 @@ public class RawDataUI implements DataUI {
         RawData rawData = null;
         String action = null;
         boolean isOptional = false;
+        String panelName = "";
         if(inputOrOutput instanceof InputDescriptionType){
             rawData = (RawData) ((InputDescriptionType)inputOrOutput).getDataDescription().getValue();
             action = OpenPanel.ACTION_OPEN;
             isOptional = ((InputDescriptionType)inputOrOutput).getMinOccurs().equals(new BigInteger("0"));
+            panelName = I18N.tr("Make your selection.");
         }
         else if(inputOrOutput instanceof OutputDescriptionType){
             rawData = (RawData) ((OutputDescriptionType)inputOrOutput).getDataDescription().getValue();
             action = OpenPanel.ACTION_SAVE;
+            panelName = I18N.tr("Save file.");
         }
 
         //Create the main panel
@@ -152,9 +155,9 @@ public class RawDataUI implements DataUI {
             dataAccepted = OpenPanel.ACCEPT_BOTH;
         }
 
-        OpenPanel openPanel = new OpenPanel("RawData.OpenPanel", I18N.tr("Make your selection."), action, dataAccepted);
+        OpenPanel openPanel = new OpenPanel("RawData.OpenPanel", panelName, action, dataAccepted);
         openPanel.loadState();
-        if(rawData.getFileTypes().length == 0) {
+        if(rawData.getFileTypes() == null || rawData.getFileTypes().length == 0) {
             openPanel.setAcceptAllFileFilterUsed(true);
         }
         else{

--- a/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/editor/process/ProcessEditableElement.java
+++ b/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/editor/process/ProcessEditableElement.java
@@ -41,6 +41,7 @@ import net.opengis.wps._2_0.*;
 import org.orbisgis.commons.progress.ProgressMonitor;
 import org.orbisgis.sif.edition.EditableElement;
 import org.orbisgis.sif.edition.EditableElementException;
+import org.orbisgis.wpsclient.api.utils.ProcessExecutionType;
 import org.orbisgis.wpsservice.controller.execution.ProcessExecutionListener;
 import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
@@ -72,8 +73,9 @@ public class ProcessEditableElement implements EditableElement {
     private boolean isOpen;
     /** List of listeners for the processState*/
     private List<PropertyChangeListener> propertyChangeListenerList;
-    /** Map of the pre defined data of a process used to display default datas */
+    /** Map of the pre defined data of a process used to display default data */
     private Map<URI, Object> dataMap;
+    private ProcessExecutionType type;
 
     /**
      * Constructor of the EditableElement using the ProcessOfferings.
@@ -192,5 +194,13 @@ public class ProcessEditableElement implements EditableElement {
      */
     public void setDefaultValues(Map<URI,Object> defaultValues) {
         dataMap.putAll(defaultValues);
+    }
+
+    public void setProcessExecutionType(ProcessExecutionType processExecutionType){
+        this.type = processExecutionType;
+    }
+
+    public ProcessExecutionType getProcessExecutionType(){
+        return type;
     }
 }

--- a/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/editor/process/ProcessEditor.java
+++ b/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/editor/process/ProcessEditor.java
@@ -60,10 +60,7 @@ import org.xnap.commons.i18n.I18nFactory;
 
 import javax.swing.*;
 import java.awt.*;
-import java.awt.event.ActionListener;
-import java.awt.event.InputEvent;
-import java.awt.event.KeyEvent;
-import java.awt.event.MouseListener;
+import java.awt.event.*;
 import java.beans.EventHandler;
 import java.math.BigInteger;
 import java.net.URI;
@@ -131,7 +128,7 @@ public class ProcessEditor extends JPanel implements EditorDockable {
 
         //Sets the docking panel parameters
         dockingPanelParameters = new DockingPanelParameters();
-        dockingPanelParameters.setName(NAME+"_"+processEditableElement.getProcess().getTitle().get(0).getValue());
+        dockingPanelParameters.setName(NAME+"_"+UUID.randomUUID().toString());
         dockingPanelParameters.setTitleIcon(ToolBoxIcon.getIcon(ToolBoxIcon.PROCESS));
         dockingPanelParameters.setDefaultDockingLocation(
                 new DockingLocation(DockingLocation.Location.STACKED_ON, WpsClientImpl.TOOLBOX_REFERENCE));
@@ -249,9 +246,6 @@ public class ProcessEditor extends JPanel implements EditorDockable {
                     job.setStartTime(System.currentTimeMillis());
                     job.setStatus(statusInfo);
                     job.setProcessState(ProcessExecutionListener.ProcessState.IDLE);
-                    //Dirty way to close the ProcessEditor
-                    this.processComponentKeyEvent(new KeyEvent(this, 1, 20, 1, 10,
-                            KeyStroke.getKeyStroke(KeyEvent.VK_F4, InputEvent.ALT_DOWN_MASK).getKeyChar()));
                 } else {
                     errorMessage.setText("Please, configure all the inputs/outputs before executing.");
                 }
@@ -287,16 +281,23 @@ public class ProcessEditor extends JPanel implements EditorDockable {
                             job.setStartTime(System.currentTimeMillis());
                             job.setStatus(statusInfo);
                             job.setProcessState(ProcessExecutionListener.ProcessState.IDLE);
-                            //Dirty way to close the ProcessEditor
-                            this.processComponentKeyEvent(new KeyEvent(this, 1, 20, 1, 10,
-                                    KeyStroke.getKeyStroke(KeyEvent.VK_F4, InputEvent.ALT_DOWN_MASK).getKeyChar()));
-
                         } else {
                             errorMessage.setText("Please, configure all the inputs/outputs before executing.");
                         }
                     }
                 }
                 break;
+        }
+        //Dirty way to close the ProcessEditor
+        try {
+            Robot robot = new Robot();
+            robot.keyPress(KeyEvent.VK_CONTROL);
+            robot.keyPress(KeyEvent.VK_F4);
+            robot.delay(100);
+            robot.keyRelease(KeyEvent.VK_CONTROL);
+            robot.keyRelease(KeyEvent.VK_F4);
+        } catch (AWTException e) {
+            e.printStackTrace();
         }
     }
 

--- a/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/editor/process/ProcessEditor.java
+++ b/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/editor/process/ProcessEditor.java
@@ -61,6 +61,8 @@ import org.xnap.commons.i18n.I18nFactory;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
 import java.awt.event.MouseListener;
 import java.beans.EventHandler;
 import java.math.BigInteger;
@@ -118,11 +120,8 @@ public class ProcessEditor extends JPanel implements EditorDockable {
      * Main constructor of the ProcessEditor.
      * @param wpsClient OrbisGIS Wps client.
      * @param processEditableElement Editable element of this editor.
-     * @param type Type of the execution to display the UI in the desired mode.
      */
-    public ProcessEditor(WpsClientImpl wpsClient,
-                         ProcessEditableElement processEditableElement,
-                         ProcessExecutionType type){
+    public ProcessEditor(WpsClientImpl wpsClient, ProcessEditableElement processEditableElement){
         this.setLayout(new BorderLayout());
         //Sets the attributes
         this.wpsClient = wpsClient;
@@ -132,7 +131,7 @@ public class ProcessEditor extends JPanel implements EditorDockable {
 
         //Sets the docking panel parameters
         dockingPanelParameters = new DockingPanelParameters();
-        dockingPanelParameters.setName(NAME+"_"+processEditableElement.getProcess().getTitle());
+        dockingPanelParameters.setName(NAME+"_"+processEditableElement.getProcess().getTitle().get(0).getValue());
         dockingPanelParameters.setTitleIcon(ToolBoxIcon.getIcon(ToolBoxIcon.PROCESS));
         dockingPanelParameters.setDefaultDockingLocation(
                 new DockingLocation(DockingLocation.Location.STACKED_ON, WpsClientImpl.TOOLBOX_REFERENCE));
@@ -158,14 +157,14 @@ public class ProcessEditor extends JPanel implements EditorDockable {
         dockingActions.addAction(toggleModeAction);
 
         //Sets the execution type of the process and build the UI
-        switch(type){
+        switch(processEditableElement.getProcessExecutionType()){
             case STANDARD:
                 this.add(buildSimpleUI(), BorderLayout.CENTER);
                 break;
             case BASH:
                 this.add(buildBashUI(), BorderLayout.CENTER);
         }
-        mode = type;
+        mode = processEditableElement.getProcessExecutionType();
         this.revalidate();
     }
 
@@ -250,6 +249,9 @@ public class ProcessEditor extends JPanel implements EditorDockable {
                     job.setStartTime(System.currentTimeMillis());
                     job.setStatus(statusInfo);
                     job.setProcessState(ProcessExecutionListener.ProcessState.IDLE);
+                    //Dirty way to close the ProcessEditor
+                    this.processComponentKeyEvent(new KeyEvent(this, 1, 20, 1, 10,
+                            KeyStroke.getKeyStroke(KeyEvent.VK_F4, InputEvent.ALT_DOWN_MASK).getKeyChar()));
                 } else {
                     errorMessage.setText("Please, configure all the inputs/outputs before executing.");
                 }
@@ -285,6 +287,9 @@ public class ProcessEditor extends JPanel implements EditorDockable {
                             job.setStartTime(System.currentTimeMillis());
                             job.setStatus(statusInfo);
                             job.setProcessState(ProcessExecutionListener.ProcessState.IDLE);
+                            //Dirty way to close the ProcessEditor
+                            this.processComponentKeyEvent(new KeyEvent(this, 1, 20, 1, 10,
+                                    KeyStroke.getKeyStroke(KeyEvent.VK_F4, InputEvent.ALT_DOWN_MASK).getKeyChar()));
 
                         } else {
                             errorMessage.setText("Please, configure all the inputs/outputs before executing.");

--- a/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/editor/process/ProcessEditorFactory.java
+++ b/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/editor/process/ProcessEditorFactory.java
@@ -1,0 +1,83 @@
+package org.orbisgis.wpsclient.impl.editor.process;
+
+import net.opengis.wps._2_0.ProcessOffering;
+import org.orbisgis.sif.docking.DockingPanelLayout;
+import org.orbisgis.sif.edition.*;
+import org.orbisgis.wpsclient.impl.WpsClientImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
+
+import java.net.URI;
+import java.util.HashMap;
+
+/**
+ *  This factory receive the {@link ProcessEditableElement} and open a new editor.
+ *
+ *  @author Sylvain PALOMINOS
+ */
+public class ProcessEditorFactory implements EditorFactory {
+    public static final String FACTORY_ID = "ProcessEditorFactory";
+    private static final Logger LOGGER = LoggerFactory.getLogger("gui." + ProcessEditorFactory.class);
+    protected final static I18n I18N = I18nFactory.getI18n(ProcessEditorFactory.class);
+    private WpsClientImpl wpsClient = null;
+    private EditorManager editorManager = null;
+
+    public ProcessEditorFactory (EditorManager editorManager, WpsClientImpl wpsClient){
+        this.editorManager = editorManager;
+        this.wpsClient = wpsClient;
+    }
+
+    @Override
+    public DockingPanelLayout makeEditableLayout(EditableElement editable) {
+        if(editable instanceof ProcessEditableElement) {
+            ProcessEditableElement editableTable = (ProcessEditableElement)editable;
+            if(isEditableAlreadyOpened(editableTable)) { //Panel already created
+                LOGGER.info(I18N.tr("This process ({0}) is already shown in an editor.",
+                        editableTable.getProcess().getTitle().get(0).getValue()));
+                return null;
+            }
+            return new ProcessPanelLayout(editableTable);
+        } else {
+            return null;
+        }
+    }
+
+    private boolean isEditableAlreadyOpened(EditableElement editable) {
+        for(Editor editor : editorManager.getEditors()) {
+            if(editor instanceof ProcessEditor && editable.equals(editor.getEditableElement())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public DockingPanelLayout makeEmptyLayout() {
+        return new ProcessPanelLayout(new ProcessEditableElement(new ProcessOffering(), new HashMap<URI, Object>()));
+    }
+
+    @Override
+    public boolean match(DockingPanelLayout layout) {
+        return layout instanceof ProcessPanelLayout;
+    }
+
+    @Override
+    public EditorDockable create(DockingPanelLayout layout) {
+        ProcessEditableElement editableElement = ((ProcessPanelLayout)layout).getProcessEditableElement();
+        //Check the DataSource state
+        return new ProcessEditor(wpsClient, editableElement);
+    }
+
+    @Override
+    public String getId() {
+        return FACTORY_ID;
+    }
+
+    @Override
+    public void dispose() {
+        //
+    }
+}
+

--- a/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/editor/process/ProcessPanelLayout.java
+++ b/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/editor/process/ProcessPanelLayout.java
@@ -1,0 +1,46 @@
+package org.orbisgis.wpsclient.impl.editor.process;
+
+import org.orbisgis.sif.docking.DockingPanelLayout;
+import org.orbisgis.sif.docking.XElement;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/**
+ *
+ *
+ * @author Sylvain PALOMINOS
+ */
+public class ProcessPanelLayout implements DockingPanelLayout {
+
+    private ProcessEditableElement processEditableElement;
+
+    public ProcessPanelLayout(ProcessEditableElement processEditableElement) {
+        this.processEditableElement = processEditableElement;
+    }
+
+    public ProcessEditableElement getProcessEditableElement() {
+        return processEditableElement;
+    }
+
+    @Override
+    public void writeStream(DataOutputStream out) throws IOException {
+
+    }
+
+    @Override
+    public void readStream(DataInputStream in) throws IOException {
+
+    }
+
+    @Override
+    public void writeXML(XElement element) {
+
+    }
+
+    @Override
+    public void readXML(XElement element) {
+
+    }
+}


### PR DESCRIPTION
Now the process editors are managed like the other editors, with an Editor, a Factory, an EditableElement and a PanelLayout. To be close on running the process, it simulates the pressing of ctrl+F4 keys. (issue #1148)
Also move the processing type (bash or simple) in the EditableElement.