### PR TITLE
Several fixes

### DIFF
--- a/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/WpsClientImpl.java
+++ b/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/WpsClientImpl.java
@@ -775,7 +775,12 @@ public class WpsClientImpl implements DockingPanel, InternalWpsClient, PropertyC
                 if(URI.create(input.getIdentifier().getValue()).equals(entry.getKey())){
                     //Build the data object containing the data on the input
                     Data data = new Data();
-                    data.getContent().add(entry.getValue().toString());
+                    if(entry.getValue() == null) {
+                        data.getContent().add(null);
+                    }
+                    else {
+                        data.getContent().add(entry.getValue().toString());
+                    }
                     //Build the DataInput object containing the input identifier and the data to process
                     DataInputType dataInput = new DataInputType();
                     dataInput.setId(entry.getKey().toString());

--- a/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/WpsClientImpl.java
+++ b/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/WpsClientImpl.java
@@ -297,7 +297,7 @@ public class WpsClientImpl implements DockingPanel, InternalWpsClient, PropertyC
      *
      * @return The list of ProcessSummaryType.
      */
-    private List<ProcessSummaryType> getCapabilities(){
+    public List<ProcessSummaryType> getCapabilities(){
         //Sets the getCapabilities request
         GetCapabilitiesType getCapabilities = new GetCapabilitiesType();
         //Sets the language
@@ -330,7 +330,7 @@ public class WpsClientImpl implements DockingPanel, InternalWpsClient, PropertyC
      * @param processIdentifier Identifier of the processes asked.
      * @return The list of the ProcessOffering
      */
-    private List<ProcessOffering> getProcessOffering(URI processIdentifier){
+    public List<ProcessOffering> getProcessOffering(URI processIdentifier){
         //Sets the describeProcess request
         DescribeProcess describeProcess = new DescribeProcess();
         //Sets the language
@@ -646,7 +646,9 @@ public class WpsClientImpl implements DockingPanel, InternalWpsClient, PropertyC
         if(defaultValuesMap != null) {
             joinedDefaultValuesMap.putAll(defaultValuesMap);
         }
-        ProcessEditableElement processEditableElement = new ProcessEditableElement(listProcess.get(0), joinedDefaultValuesMap);
+        ProcessOffering processOffering = listProcess.get(0);
+        URI processUri = URI.create(processOffering.getProcess().getIdentifier().getValue());
+        ProcessEditableElement processEditableElement = new ProcessEditableElement(processOffering , processUri, joinedDefaultValuesMap);
         processEditableElement.setProcessExecutionType(type);
         editorManager.openEditable(processEditableElement);
     }

--- a/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/dataui/RawDataUI.java
+++ b/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/dataui/RawDataUI.java
@@ -117,7 +117,7 @@ public class RawDataUI implements DataUI {
         else if(inputOrOutput instanceof OutputDescriptionType){
             rawData = (RawData) ((OutputDescriptionType)inputOrOutput).getDataDescription().getValue();
             action = OpenPanel.ACTION_SAVE;
-            panelName = I18N.tr("Save file.");
+            panelName = I18N.tr("Save to.");
         }
 
         //Create the main panel

--- a/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/editor/process/ProcessEditableElement.java
+++ b/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/editor/process/ProcessEditableElement.java
@@ -42,6 +42,7 @@ import org.orbisgis.commons.progress.ProgressMonitor;
 import org.orbisgis.sif.edition.EditableElement;
 import org.orbisgis.sif.edition.EditableElementException;
 import org.orbisgis.wpsclient.api.utils.ProcessExecutionType;
+import org.orbisgis.wpsclient.impl.WpsClientImpl;
 import org.orbisgis.wpsservice.controller.execution.ProcessExecutionListener;
 import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
@@ -76,6 +77,7 @@ public class ProcessEditableElement implements EditableElement {
     /** Map of the pre defined data of a process used to display default data */
     private Map<URI, Object> dataMap;
     private ProcessExecutionType type;
+    private URI processURI;
 
     /**
      * Constructor of the EditableElement using the ProcessOfferings.
@@ -84,8 +86,9 @@ public class ProcessEditableElement implements EditableElement {
      * @param defaultDataMap Map containing the default values for the process. The default values will automatically
      *                       fill the UI fields.
      */
-    public ProcessEditableElement(ProcessOffering processOffering, Map<URI, Object> defaultDataMap){
+    public ProcessEditableElement(ProcessOffering processOffering, URI processURI, Map<URI, Object> defaultDataMap){
         this.processOffering = processOffering;
+        this.processURI = processURI;
         this.propertyChangeListenerList = new ArrayList<>();
         this.dataMap = defaultDataMap;
         type = ProcessExecutionType.STANDARD;
@@ -176,15 +179,30 @@ public class ProcessEditableElement implements EditableElement {
      * @return The process.
      */
     public ProcessDescriptionType getProcess() {
-        return processOffering.getProcess();
+        return getProcessOffering(null).getProcess();
     }
 
     /**
-     * Returns the ProcessOffering object.
+     * Returns the process.
+     *
+     * @return The process.
+     */
+    public URI getProcessURI() {
+        return processURI;
+    }
+
+    /**
+     * Returns the cache ProcessOffering object or get it from the WpsClient with the process URI.
      *
      * @return the ProcessOffering object.
      */
-    public ProcessOffering getProcessOffering() {
+    public ProcessOffering getProcessOffering(WpsClientImpl wpsClient) {
+        if(processOffering == null && wpsClient != null){
+            List<ProcessOffering> processOfferingList = wpsClient.getProcessOffering(processURI);
+            if(processOfferingList != null && !processOfferingList.isEmpty()) {
+                processOffering = processOfferingList.get(0);
+            }
+        }
         return processOffering;
     }
 

--- a/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/editor/process/ProcessEditableElement.java
+++ b/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/editor/process/ProcessEditableElement.java
@@ -88,6 +88,7 @@ public class ProcessEditableElement implements EditableElement {
         this.processOffering = processOffering;
         this.propertyChangeListenerList = new ArrayList<>();
         this.dataMap = defaultDataMap;
+        type = ProcessExecutionType.STANDARD;
     }
 
     @Override

--- a/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/editor/process/ProcessEditor.java
+++ b/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/editor/process/ProcessEditor.java
@@ -97,7 +97,7 @@ public class ProcessEditor extends JPanel implements EditorDockable {
     /** OrbisGIS Wps client. */
     private WpsClientImpl wpsClient;
     /** Docking parameters. */
-    private DockingPanelParameters dockingPanelParameters;
+    private DockingPanelParameters dockingPanelParameters = new DockingPanelParameters();;
     /** DataUIManager used to create the UI corresponding the the data */
     private DataUIManager dataUIManager;
     /** Error label displayed when the process inputs and output are all defined. */
@@ -119,6 +119,10 @@ public class ProcessEditor extends JPanel implements EditorDockable {
      * @param processEditableElement Editable element of this editor.
      */
     public ProcessEditor(WpsClientImpl wpsClient, ProcessEditableElement processEditableElement){
+        if(processEditableElement.getProcessOffering(wpsClient) == null){
+            LOGGER.error(I18N.tr("Unable to load the ProcessEditor (0).", processEditableElement.getProcessURI()));
+            return;
+        }
         this.setLayout(new BorderLayout());
         //Sets the attributes
         this.wpsClient = wpsClient;
@@ -127,7 +131,6 @@ public class ProcessEditor extends JPanel implements EditorDockable {
         this.dataUIManager = wpsClient.getDataUIManager();
 
         //Sets the docking panel parameters
-        dockingPanelParameters = new DockingPanelParameters();
         dockingPanelParameters.setName(NAME+"_"+processEditableElement.getProcess().getTitle().get(0).getValue());
         dockingPanelParameters.setTitleIcon(ToolBoxIcon.getIcon(ToolBoxIcon.PROCESS));
         dockingPanelParameters.setDefaultDockingLocation(
@@ -324,11 +327,11 @@ public class ProcessEditor extends JPanel implements EditorDockable {
         processPanel.add(label, "growx, span");
         //The process version
         String versionStr = I18N.tr("Version : ");
-        if(processEditableElement.getProcessOffering().getProcessVersion().isEmpty()){
+        if(processEditableElement.getProcessOffering(wpsClient).getProcessVersion().isEmpty()){
             versionStr += I18N.tr("unknown");
         }
         else{
-            versionStr += processEditableElement.getProcessOffering().getProcessVersion();
+            versionStr += processEditableElement.getProcessOffering(wpsClient).getProcessVersion();
         }
         JLabel version = new JLabel(versionStr);
         version.setFont(version.getFont().deriveFont(Font.ITALIC));
@@ -446,11 +449,11 @@ public class ProcessEditor extends JPanel implements EditorDockable {
         processPanel.add(label, "growx, span");
         //The process version
         String versionStr = I18N.tr("Version : ");
-        if(processEditableElement.getProcessOffering().getProcessVersion().isEmpty()){
+        if(processEditableElement.getProcessOffering(wpsClient).getProcessVersion().isEmpty()){
             versionStr += I18N.tr("unknown");
         }
         else{
-            versionStr += processEditableElement.getProcessOffering().getProcessVersion();
+            versionStr += processEditableElement.getProcessOffering(wpsClient).getProcessVersion();
         }
         JLabel version = new JLabel(versionStr);
         version.setFont(version.getFont().deriveFont(Font.ITALIC));

--- a/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/editor/process/ProcessEditor.java
+++ b/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/editor/process/ProcessEditor.java
@@ -128,7 +128,7 @@ public class ProcessEditor extends JPanel implements EditorDockable {
 
         //Sets the docking panel parameters
         dockingPanelParameters = new DockingPanelParameters();
-        dockingPanelParameters.setName(NAME+"_"+UUID.randomUUID().toString());
+        dockingPanelParameters.setName(NAME+"_"+processEditableElement.getProcess().getTitle().get(0).getValue());
         dockingPanelParameters.setTitleIcon(ToolBoxIcon.getIcon(ToolBoxIcon.PROCESS));
         dockingPanelParameters.setDefaultDockingLocation(
                 new DockingLocation(DockingLocation.Location.STACKED_ON, WpsClientImpl.TOOLBOX_REFERENCE));
@@ -516,17 +516,23 @@ public class ProcessEditor extends JPanel implements EditorDockable {
         }
         parameterPanel.add(new JSeparator(), "growx, span");
 
+        boolean isRowAdd = false;
         //Adds a first component row if the default data map is empty
         if(processEditableElement.getDataMap() == null || processEditableElement.getDataMap().size() == 0) {
             onAddBashRow(wpsClient.getProcessCopy(uri), parameterPanel, new HashMap<URI, Object>());
+            isRowAdd = true;
         }
         //If the default data map contains maps of data, adds a row for each map
         else{
             for(Map.Entry<URI, Object> entry : processEditableElement.getDataMap().entrySet()){
                 if(entry.getValue() instanceof Map) {
                     onAddBashRow(wpsClient.getProcessCopy(uri), parameterPanel, (Map<URI, Object>)entry.getValue());
+                    isRowAdd = true;
                 }
             }
+        }
+        if(!isRowAdd){
+            onAddBashRow(wpsClient.getProcessCopy(uri), parameterPanel, processEditableElement.getDataMap());
         }
 
         //Adds the add new row button at the very en of the UI

--- a/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/editor/process/ProcessEditorFactory.java
+++ b/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/editor/process/ProcessEditorFactory.java
@@ -1,6 +1,5 @@
 package org.orbisgis.wpsclient.impl.editor.process;
 
-import net.opengis.wps._2_0.ProcessOffering;
 import org.orbisgis.sif.docking.DockingPanelLayout;
 import org.orbisgis.sif.edition.*;
 import org.orbisgis.wpsclient.impl.WpsClientImpl;
@@ -38,7 +37,7 @@ public class ProcessEditorFactory implements EditorFactory {
                         editableTable.getProcess().getTitle().get(0).getValue()));
                 return null;
             }
-            return new ProcessPanelLayout(editableTable);
+            return new ProcessPanelLayout(editableTable, wpsClient);
         } else {
             return null;
         }
@@ -55,7 +54,7 @@ public class ProcessEditorFactory implements EditorFactory {
 
     @Override
     public DockingPanelLayout makeEmptyLayout() {
-        return new ProcessPanelLayout(new ProcessEditableElement(new ProcessOffering(), new HashMap<URI, Object>()));
+        return new ProcessPanelLayout(new ProcessEditableElement(null, null, new HashMap<URI, Object>()), wpsClient);
     }
 
     @Override

--- a/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/editor/process/ProcessPanelLayout.java
+++ b/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/editor/process/ProcessPanelLayout.java
@@ -1,11 +1,17 @@
 package org.orbisgis.wpsclient.impl.editor.process;
 
+import net.opengis.wps._2_0.ProcessOffering;
 import org.orbisgis.sif.docking.DockingPanelLayout;
 import org.orbisgis.sif.docking.XElement;
+import org.orbisgis.wpsclient.api.utils.ProcessExecutionType;
+import org.orbisgis.wpsclient.impl.WpsClientImpl;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
 
 /**
  *
@@ -15,9 +21,11 @@ import java.io.IOException;
 public class ProcessPanelLayout implements DockingPanelLayout {
 
     private ProcessEditableElement processEditableElement;
+    private WpsClientImpl wpsClient;
 
-    public ProcessPanelLayout(ProcessEditableElement processEditableElement) {
+    public ProcessPanelLayout(ProcessEditableElement processEditableElement, WpsClientImpl wpsClient) {
         this.processEditableElement = processEditableElement;
+        this.wpsClient = wpsClient;
     }
 
     public ProcessEditableElement getProcessEditableElement() {
@@ -26,21 +34,43 @@ public class ProcessPanelLayout implements DockingPanelLayout {
 
     @Override
     public void writeStream(DataOutputStream out) throws IOException {
-
+        out.writeUTF(processEditableElement.getProcess().getIdentifier().getValue());
+        out.writeUTF(processEditableElement.getProcessExecutionType().name());
     }
 
     @Override
     public void readStream(DataInputStream in) throws IOException {
-
+        URI identifier = URI.create(in.readUTF());
+        ProcessExecutionType processExecutionType = ProcessExecutionType.valueOf(in.readUTF());
+        ProcessOffering processOffering = null;
+        if(wpsClient != null) {
+            List<ProcessOffering> processOfferingList = wpsClient.getProcessOffering(identifier);
+            if (processOfferingList != null && processOfferingList.size() != 0) {
+                processOffering = processOfferingList.get(0);
+            }
+        }
+        processEditableElement = new ProcessEditableElement(processOffering, identifier, new HashMap<URI, Object>());
+        processEditableElement.setProcessExecutionType(processExecutionType);
     }
 
     @Override
     public void writeXML(XElement element) {
-
+        element.addString("processUri", processEditableElement.getProcess().getIdentifier().getValue());
+        element.addString("executionType", processEditableElement.getProcessExecutionType().name());
     }
 
     @Override
     public void readXML(XElement element) {
-
+        URI identifier = URI.create(element.getString("processUri"));
+        ProcessExecutionType processExecutionType = ProcessExecutionType.valueOf(element.getString("executionType"));
+        ProcessOffering processOffering = null;
+        if(wpsClient != null) {
+            List<ProcessOffering> processOfferingList = wpsClient.getProcessOffering(identifier);
+            if (processOfferingList != null && processOfferingList.size() != 0) {
+                processOffering = processOfferingList.get(0);
+            }
+        }
+        processEditableElement = new ProcessEditableElement(processOffering, identifier, new HashMap<URI, Object>());
+        processEditableElement.setProcessExecutionType(processExecutionType);
     }
 }


### PR DESCRIPTION
Adds by default one line to the process editor UI when it is in 'bash' mode. (maybe link to #1167)
Changes the RawDataUI save panel title to 'Save to' (issue #1157)
Fixes the bug get on unselecting a process optional value and running it. (maybe link to #1145)
Now when OrbisGIS is closed with an open process editor, on relaunching it, the process editor is restored.