### PR TITLE
Fixes

### DIFF
--- a/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/WpsClientImpl.java
+++ b/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/WpsClientImpl.java
@@ -398,8 +398,10 @@ public class WpsClientImpl implements DockingPanel, InternalWpsClient, PropertyC
         openFilePanel.loadState();
         //Wait the window answer and if the user validate set and run the export thread.
         if(UIFactory.showDialog(openFilePanel)){
-            addLocalSource(openFilePanel.getSelectedFile().toURI());
-            openFilePanel.saveState();
+            for(File file : openFilePanel.getSelectedFiles()) {
+                addLocalSource(file.toURI());
+                openFilePanel.saveState();
+            }
         }
     }
 

--- a/bundles/wps/wps-service-scripts/src/main/java/org/orbisgis/wpsservicescripts/WpsScriptsPackage.java
+++ b/bundles/wps/wps-service-scripts/src/main/java/org/orbisgis/wpsservicescripts/WpsScriptsPackage.java
@@ -157,15 +157,13 @@ public class WpsScriptsPackage {
                 icons,
                 false,
                 path);
-        if(piList == null || piList.isEmpty()){
-            LOGGER.error(I18N.tr("Error get on adding the process {0} to the WpsService, no process returned.", processpath));
-            return;
-        }
-        for(ProcessIdentifier pi : piList){
-            if(pi == null || pi.getProcessDescriptionType() == null || pi.getProcessDescriptionType().getInput() == null){
-                LOGGER.error(I18N.tr("Error, the ProcessIdentifier get is malformed."));
+        if(piList != null) {
+            for (ProcessIdentifier pi : piList) {
+                if (pi == null || pi.getProcessDescriptionType() == null || pi.getProcessDescriptionType().getInput() == null) {
+                    LOGGER.error(I18N.tr("Error, the ProcessIdentifier get is malformed."));
+                }
+                listIdProcess.add(pi.getProcessDescriptionType().getIdentifier());
             }
-            listIdProcess.add(pi.getProcessDescriptionType().getIdentifier());
         }
     }
 

--- a/bundles/wps/wps-service/src/main/java/org/orbisgis/wpsservice/LocalWpsServerImpl.java
+++ b/bundles/wps/wps-service/src/main/java/org/orbisgis/wpsservice/LocalWpsServerImpl.java
@@ -260,7 +260,7 @@ public class LocalWpsServerImpl
             if(pi == null) {
                 LOGGER.error(I18N.tr("The process {0} can not be loaded.", f.getName()));
             }
-            else if(pi.getProcessDescriptionType() != null){
+            else if(pi.getProcessOffering() != null && pi.getProcessDescriptionType() != null){
                 piList.add(pi);
             }
         }

--- a/bundles/wps/wps-service/src/main/java/org/orbisgis/wpsservice/LocalWpsServerImpl.java
+++ b/bundles/wps/wps-service/src/main/java/org/orbisgis/wpsservice/LocalWpsServerImpl.java
@@ -257,10 +257,7 @@ public class LocalWpsServerImpl
         List<ProcessIdentifier> piList = new ArrayList<>();
         if(f.getName().endsWith(GROOVY_EXTENSION)) {
             ProcessIdentifier pi = this.getProcessManager().addScript(f.toURI(), iconName, isRemovable, nodePath);
-            if(pi == null) {
-                LOGGER.error(I18N.tr("The process {0} can not be loaded.", f.getName()));
-            }
-            else if(pi.getProcessOffering() != null && pi.getProcessDescriptionType() != null){
+            if(pi != null && pi.getProcessOffering() != null && pi.getProcessDescriptionType() != null){
                 piList.add(pi);
             }
         }

--- a/bundles/wps/wps-service/src/main/java/org/orbisgis/wpsservice/controller/execution/ProcessWorker.java
+++ b/bundles/wps/wps-service/src/main/java/org/orbisgis/wpsservice/controller/execution/ProcessWorker.java
@@ -58,6 +58,9 @@ import java.util.Map;
  */
 public class ProcessWorker extends SwingWorkerPM {
 
+    /** One hundred */
+    private static final long ONE_HUNDRED = 100;
+
     /** Process execution listener which will be watching the execution */
     private Job job;
     /** Process to execute */
@@ -81,6 +84,7 @@ public class ProcessWorker extends SwingWorkerPM {
                          ProcessManager processManager,
                          Map<URI, Object> dataMap,
                          Map<String, Object> propertiesMap){
+        super(job.getProcess().getTitle().get(0).getValue(), ONE_HUNDRED);
         this.job = job;
         this.addPropertyChangeListener(Job.PROGRESS_PROPERTY, this.job);
         this.processIdentifier = processIdentifier;
@@ -88,7 +92,6 @@ public class ProcessWorker extends SwingWorkerPM {
         this.processManager = processManager;
         this.dataMap = dataMap;
         this.propertiesMap = propertiesMap;
-        this.setTaskName(job.getProcess().getTitle().get(0).getValue());
     }
 
     /**

--- a/bundles/wps/wps-service/src/main/java/org/orbisgis/wpsservice/controller/process/ProcessManager.java
+++ b/bundles/wps/wps-service/src/main/java/org/orbisgis/wpsservice/controller/process/ProcessManager.java
@@ -108,6 +108,12 @@ public class ProcessManager {
             try {
                 processOffering = parserController.parseProcess(f.getAbsolutePath());
                 if(processOffering == null){
+                    LOGGER.error(I18N.tr("Unable to parse the process {0}.", scriptUri));
+                    return null;
+                }
+                if(getProcess(processOffering.getProcess().getIdentifier()) != null){
+                    LOGGER.warn(I18N.tr("A process with the identifier {0} already exists.",
+                            processOffering.getProcess().getIdentifier().getValue()));
                     return null;
                 }
                 //Check if the process is compatible with the DBMS connected to OrbisGIS.
@@ -170,6 +176,7 @@ public class ProcessManager {
                 return pi;
             }
         }
+        LOGGER.error(I18N.tr("The script is not valid."));
         return null;
     }
 


### PR DESCRIPTION
Fixes the null pointer exception get with a postgis database (issue #1174)
Fixes the progression of a WPS process. To set the progression of a process, the method `progressMonitor.progressTo(int progression)` should be called. (issue #1062)
Fixes the add of a process with an already use identifier. (issue #1173)