### PR TITLE
Adds orbisgis file for ppa installation.

### DIFF
--- a/orbisgis-dist/src/bin/zip/orbisgis
+++ b/orbisgis-dist/src/bin/zip/orbisgis
@@ -1,0 +1,10 @@
+#!/bin/bash
+if [ $# -eq 0 ]
+then
+	bash /usr/lib/OrbisGIS/orbisgis.sh
+else
+	if [ $1 == "-clean" ]
+	then
+		bash /usr/lib/OrbisGIS/orbisgis_safemode.sh
+	fi
+fi

--- a/orbisgis-dist/src/main/assembly/bin.xml
+++ b/orbisgis-dist/src/main/assembly/bin.xml
@@ -50,6 +50,7 @@
             <includes>
                 <include>*.sh</include>
                 <include>*.bat</include>
+                <include>orbisgis</include>
             </includes>
         </fileSet>
     </fileSets>


### PR DESCRIPTION
Adds the orbisgis file which will be used on installing OrbisGIS throw the ubuntu ppa. This file will be placed in the /usr/bin folder.