### PR TITLE
Fixes the table listing on a PostGIS database

### DIFF
--- a/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/dataui/JDBCTableFieldValueUI.java
+++ b/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/dataui/JDBCTableFieldValueUI.java
@@ -46,6 +46,7 @@ import org.orbisgis.sif.common.ContainerItem;
 import org.orbisgis.wpsclient.impl.WpsClientImpl;
 import org.orbisgis.wpsclient.api.dataui.DataUI;
 import org.orbisgis.wpsclient.impl.utils.ToolBoxIcon;
+import org.orbisgis.wpsclient.impl.utils.WaitLayerUI;
 import org.orbisgis.wpsservice.model.*;
 import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
@@ -428,117 +429,6 @@ public class JDBCTableFieldValueUI implements DataUI {
             list.revalidate();
             list.repaint();
             return null;
-        }
-    }
-
-    /**
-     * Wait layer displayed on doing an update on the list.
-     */
-    private class WaitLayerUI extends LayerUI<JComponent> implements ActionListener {
-        private boolean mIsRunning;
-        private boolean mIsFadingOut;
-        private Timer mTimer;
-
-        private int mAngle;
-        private int mFadeCount;
-        private int mFadeLimit = 15;
-
-        @Override
-        public void paint(Graphics g, JComponent c) {
-            int w = c.getWidth();
-            int h = c.getHeight();
-
-            // Paint the view.
-            super.paint (g, c);
-
-            if (!mIsRunning) {
-                return;
-            }
-
-            Graphics2D g2 = (Graphics2D)g.create();
-
-            float fade = (float)mFadeCount / (float)mFadeLimit;
-            // Gray it out.
-            Composite urComposite = g2.getComposite();
-            g2.setComposite(AlphaComposite.getInstance(
-                    AlphaComposite.SRC_OVER, .5f * fade));
-            g2.fillRect(0, 0, w, h);
-            g2.setComposite(urComposite);
-
-            // Paint the wait indicator.
-            int s = Math.min(w, h) / 5;
-            int cx = w / 2;
-            int cy = h / 2;
-            g2.setPaint(Color.white);
-            //"Loading source" painting
-            Font font = g2.getFont().deriveFont(Font.PLAIN, s / 3);
-            g2.setFont(font);
-            FontMetrics metrics = g2.getFontMetrics(font);
-            int w1 = metrics.stringWidth(I18N.tr("Loading"));
-            int w2 = metrics.stringWidth(I18N.tr("fields"));
-            int h1 = metrics.getHeight();
-            g2.drawString(I18N.tr("Loading"), cx - w1 / 2, cy - h1 / 2);
-            g2.drawString(I18N.tr("source"), cx - w2 / 2, cy + h1 / 2);
-            //waiter painting
-            g2.setStroke(new BasicStroke(s / 4, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
-            g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
-                    RenderingHints.VALUE_ANTIALIAS_ON);
-
-            g2.rotate(Math.PI * mAngle / 180, cx, cy);
-            for (int i = 1; i < 12; i++) {
-                float scale = (11.0f - (float)i) / 11.0f;
-                g2.drawLine(cx + s, cy, cx + s * 2, cy);
-                g2.rotate(-Math.PI / 6, cx, cy);
-                g2.setComposite(AlphaComposite.getInstance(
-                        AlphaComposite.SRC_OVER, scale * fade));
-            }
-            Toolkit.getDefaultToolkit().sync();
-            g2.dispose();
-        }
-
-        public void actionPerformed(ActionEvent e) {
-            if (mIsRunning) {
-                firePropertyChange("tick", 0, 1);
-                mAngle += 3;
-                if (mAngle >= 360) {
-                    mAngle = 0;
-                }
-                if (mIsFadingOut) {
-                    if (--mFadeCount <= 0) {
-                        mIsRunning = false;
-                        mTimer.stop();
-                    }
-                }
-                else if (mFadeCount < mFadeLimit) {
-                    mFadeCount++;
-                }
-            }
-        }
-
-        public void start() {
-            if (mIsRunning) {
-                return;
-            }
-
-            // Run a thread for animation.
-            mIsRunning = true;
-            mIsFadingOut = false;
-            mFadeCount = 0;
-            int fps = 24;
-            int tick = 1000 / fps;
-            mTimer = new Timer(tick, this);
-            mTimer.start();
-        }
-
-        public void stop() {
-            mIsFadingOut = true;
-        }
-
-        @Override
-        public void applyPropertyChange(PropertyChangeEvent pce, JLayer l) {
-            if ("tick".equals(pce.getPropertyName())) {
-                l.repaint();
-            }
         }
     }
 }

--- a/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/utils/WaitLayerUI.java
+++ b/bundles/wps/wps-client/src/main/java/org/orbisgis/wpsclient/impl/utils/WaitLayerUI.java
@@ -1,0 +1,125 @@
+package org.orbisgis.wpsclient.impl.utils;
+
+import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
+
+import javax.swing.*;
+import javax.swing.plaf.LayerUI;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.beans.PropertyChangeEvent;
+
+/**
+ * Wait layer displayed on doing an update on the list.
+ *
+ * @author Sylvain PALOMINOS
+ */
+public class WaitLayerUI extends LayerUI<JComponent> implements ActionListener {
+    private boolean mIsRunning;
+    private boolean mIsFadingOut;
+    private Timer mTimer;
+
+    private int mAngle;
+    private int mFadeCount;
+    private int mFadeLimit = 15;
+    private static final I18n I18N = I18nFactory.getI18n(WaitLayerUI.class);
+
+    @Override
+    public void paint(Graphics g, JComponent c) {
+        int w = c.getWidth();
+        int h = c.getHeight();
+
+        // Paint the view.
+        super.paint (g, c);
+
+        if (!mIsRunning) {
+            return;
+        }
+
+        Graphics2D g2 = (Graphics2D)g.create();
+
+        float fade = (float)mFadeCount / (float)mFadeLimit;
+        // Gray it out.
+        Composite urComposite = g2.getComposite();
+        g2.setComposite(AlphaComposite.getInstance(
+                AlphaComposite.SRC_OVER, .5f * fade));
+        g2.fillRect(0, 0, w, h);
+        g2.setComposite(urComposite);
+
+        // Paint the wait indicator.
+        int s = Math.min(w, h) / 5;
+        int cx = w / 2;
+        int cy = h / 2;
+        g2.setPaint(Color.white);
+        //"Loading source" painting
+        Font font = g2.getFont().deriveFont(Font.PLAIN, s / 3);
+        g2.setFont(font);
+        FontMetrics metrics = g2.getFontMetrics(font);
+        int w1 = metrics.stringWidth(I18N.tr("Loading"));
+        int w2 = metrics.stringWidth(I18N.tr("fields"));
+        int h1 = metrics.getHeight();
+        g2.drawString(I18N.tr("Loading"), cx - w1 / 2, cy - h1 / 2);
+        g2.drawString(I18N.tr("source"), cx - w2 / 2, cy + h1 / 2);
+        //waiter painting
+        g2.setStroke(new BasicStroke(s / 4, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+        g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
+                RenderingHints.VALUE_ANTIALIAS_ON);
+
+        g2.rotate(Math.PI * mAngle / 180, cx, cy);
+        for (int i = 1; i < 12; i++) {
+            float scale = (11.0f - (float)i) / 11.0f;
+            g2.drawLine(cx + s, cy, cx + s * 2, cy);
+            g2.rotate(-Math.PI / 6, cx, cy);
+            g2.setComposite(AlphaComposite.getInstance(
+                    AlphaComposite.SRC_OVER, scale * fade));
+        }
+        Toolkit.getDefaultToolkit().sync();
+        g2.dispose();
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        if (mIsRunning) {
+            firePropertyChange("tick", 0, 1);
+            mAngle += 3;
+            if (mAngle >= 360) {
+                mAngle = 0;
+            }
+            if (mIsFadingOut) {
+                if (--mFadeCount <= 0) {
+                    mIsRunning = false;
+                    mTimer.stop();
+                }
+            }
+            else if (mFadeCount < mFadeLimit) {
+                mFadeCount++;
+            }
+        }
+    }
+
+    public void start() {
+        if (mIsRunning) {
+            return;
+        }
+
+        // Run a thread for animation.
+        mIsRunning = true;
+        mIsFadingOut = false;
+        mFadeCount = 0;
+        int fps = 24;
+        int tick = 1000 / fps;
+        mTimer = new Timer(tick, this);
+        mTimer.start();
+    }
+
+    public void stop() {
+        mIsFadingOut = true;
+    }
+
+    @Override
+    public void applyPropertyChange(PropertyChangeEvent pce, JLayer l) {
+        if ("tick".equals(pce.getPropertyName())) {
+            l.repaint();
+        }
+    }
+}

--- a/bundles/wps/wps-service-orbisgis/pom.xml
+++ b/bundles/wps/wps-service-orbisgis/pom.xml
@@ -141,6 +141,12 @@
             <artifactId>wps-service</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.orbisgis</groupId>
+            <artifactId>h2gis-functions</artifactId>
+            <version>${h2-gis-version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/bundles/wps/wps-service-orbisgis/src/main/java/org/orbisgis/wpsserviceorbisgis/OrbisGISWpsServerImpl.java
+++ b/bundles/wps/wps-service-orbisgis/src/main/java/org/orbisgis/wpsserviceorbisgis/OrbisGISWpsServerImpl.java
@@ -40,6 +40,7 @@ package org.orbisgis.wpsserviceorbisgis;
 import net.opengis.ows._2.*;
 import net.opengis.wps._2_0.DescribeProcess;
 import net.opengis.wps._2_0.ProcessOfferings;
+import org.h2.jdbc.JdbcResultSet;
 import org.h2gis.utilities.JDBCUtilities;
 import org.h2gis.utilities.SFSUtilities;
 import org.h2gis.utilities.TableLocation;
@@ -312,6 +313,41 @@ public class OrbisGISWpsServerImpl
                                 for (DataType dataType : excludedTypes) {
                                     if (DataType.testGeometryType(dataType, entry.getValue())) {
                                         isValid = false;
+                                    }
+                                }
+                            }
+                        }
+                    } catch (SQLException e) {
+                        LOGGER.error(I18N.tr("Unable to get the connection.\nCause : {0}.",
+                                e.getMessage()));
+                    }
+                }
+                else {
+                    try (Connection connection = dataManager.getDataSource().getConnection()) {
+                        //Get the metadata of the table
+                        ResultSet rs = connection.createStatement().executeQuery(String.format("select * from %s", tablelocation.getTable()));
+                        ResultSetMetaData metaData = rs.getMetaData();
+                        //For each field, get its DataType
+                        for(int fieldId = 1; fieldId <= metaData.getColumnCount(); ++fieldId) {
+                            String fieldTypeName = metaData.getColumnTypeName(fieldId);
+                            if(!fieldTypeName.equalsIgnoreCase("geometry")) {
+                                DataType dataType = DataType.getDataType(metaData.getColumnType(fieldId));
+                                //Tests if the DataType is compatible with the acceptedTypes and excludedTypes.
+                                if(dataTypes != null && !dataTypes.isEmpty()) {
+                                    for (DataType acceptedType : dataTypes) {
+                                        if (dataType.equals(acceptedType)) {
+                                            isValid = true;
+                                        }
+                                    }
+                                }
+                                else{
+                                    isValid = true;
+                                }
+                                if(excludedTypes != null && !excludedTypes.isEmpty()) {
+                                    for (DataType excludedType : excludedTypes) {
+                                        if (excludedType.equals(dataType)) {
+                                            isValid = false;
+                                        }
                                     }
                                 }
                             }

--- a/bundles/wps/wps-service-orbisgis/src/main/java/org/orbisgis/wpsserviceorbisgis/OrbisGISWpsServerImpl.java
+++ b/bundles/wps/wps-service-orbisgis/src/main/java/org/orbisgis/wpsserviceorbisgis/OrbisGISWpsServerImpl.java
@@ -38,6 +38,8 @@
 package org.orbisgis.wpsserviceorbisgis;
 
 import net.opengis.ows._2.*;
+import net.opengis.wps._2_0.DescribeProcess;
+import net.opengis.wps._2_0.ProcessOfferings;
 import org.h2gis.utilities.JDBCUtilities;
 import org.h2gis.utilities.SFSUtilities;
 import org.h2gis.utilities.TableLocation;
@@ -275,6 +277,12 @@ public class OrbisGISWpsServerImpl
             return (processManager.getProcess(pi.getProcessDescriptionType().getIdentifier()) != null);
         }
         return false;
+    }
+
+    @Override
+    public ProcessOfferings describeProcess(DescribeProcess describeProcess){
+        this.onDataManagerChange();
+        return super.describeProcess(describeProcess);
     }
 
     @Override

--- a/bundles/wps/wps-service-orbisgis/src/test/java/org/orbisgis/wpsserviceorbisgis/JDBCUtilityTest.java
+++ b/bundles/wps/wps-service-orbisgis/src/test/java/org/orbisgis/wpsserviceorbisgis/JDBCUtilityTest.java
@@ -1,0 +1,219 @@
+package org.orbisgis.wpsserviceorbisgis;
+/**
+ * OrbisGIS is a java GIS application dedicated to research in GIScience.
+ * OrbisGIS is developed by the GIS group of the DECIDE team of the
+ * Lab-STICC CNRS laboratory, see <http://www.lab-sticc.fr/>.
+ *
+ * The GIS group of the DECIDE team is located at :
+ *
+ * Laboratoire Lab-STICC – CNRS UMR 6285
+ * Equipe DECIDE
+ * UNIVERSITÉ DE BRETAGNE-SUD
+ * Institut Universitaire de Technologie de Vannes
+ * 8, Rue Montaigne - BP 561 56017 Vannes Cedex
+ *
+ * OrbisGIS is distributed under GPL 3 license.
+ *
+ * Copyright (C) 2007-2014 CNRS (IRSTV FR CNRS 2488)
+ * Copyright (C) 2015-2017 CNRS (Lab-STICC UMR CNRS 6285)
+ *
+ * This file is part of OrbisGIS.
+ *
+ * OrbisGIS is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * OrbisGIS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * OrbisGIS. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
+
+import org.h2gis.functions.factory.H2GISDBFactory;
+import org.h2gis.functions.factory.H2GISFunctions;
+import org.h2gis.functions.io.DriverManager;
+import org.h2gis.utilities.SFSUtilities;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.orbisgis.corejdbc.DataManager;
+import org.orbisgis.corejdbc.internal.DataManagerImpl;
+import org.orbisgis.frameworkapi.CoreWorkspace;
+import org.orbisgis.wpsservice.model.DataType;
+
+import javax.sql.DataSource;
+import java.beans.PropertyChangeListener;
+import java.io.File;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Sylvain PALOMINOS
+ */
+public class JDBCUtilityTest {
+    private static OrbisGISWpsServerImpl wpsServer;
+    private static DataSource dataSource;
+    private static Connection connection;
+
+    @Before
+    public void init() throws Exception {
+        wpsServer = new OrbisGISWpsServerImpl();
+        dataSource = SFSUtilities.wrapSpatialDataSource(
+                H2GISDBFactory.createDataSource(JDBCUtilityTest.class.getSimpleName(), true));
+        connection = dataSource.getConnection();
+        H2GISFunctions.registerFunction(connection.createStatement(), new DriverManager(), "");
+        DataManager dataManager = new DataManagerImpl(dataSource);
+        wpsServer.setDataManager(dataManager);
+        wpsServer.setCoreWorkspace(new CustomCoreWorkspace());
+        wpsServer.initialisation();
+    }
+
+    @Test
+    public void testGetTableFields() throws SQLException {
+        try(Statement st = connection.createStatement()) {
+            st.execute("DROP TABLE TABLE IF EXISTS");
+            try {
+                st.execute("CREATE TABLE TABLE (\"integers\" integer, \"geometries\" geometry)");
+
+                List<DataType> dataTypeList = new ArrayList<>();
+                List<DataType> excludedTypeList = new ArrayList<>();
+                List<String> fieldList = wpsServer.getTableFieldList("TABLE", dataTypeList, excludedTypeList);
+                Assert.assertTrue("The field list should contains the field 'geometries'.", fieldList.contains("geometries"));
+                Assert.assertTrue("The field list should contains the field 'integers'.", fieldList.contains("integers"));
+
+                dataTypeList = new ArrayList<>();
+                dataTypeList.add(DataType.GEOMETRY);
+                excludedTypeList = new ArrayList<>();
+                fieldList = wpsServer.getTableFieldList("TABLE", dataTypeList, excludedTypeList);
+                Assert.assertTrue("The field list should contains the field 'geometries'.", fieldList.contains("geometries"));
+                Assert.assertFalse("The field list should not contains the field 'integers'.", fieldList.contains("integers"));
+
+                dataTypeList = new ArrayList<>();
+                excludedTypeList = new ArrayList<>();
+                excludedTypeList.add(DataType.GEOMETRY);
+                fieldList = wpsServer.getTableFieldList("TABLE", dataTypeList, excludedTypeList);
+                Assert.assertFalse("The field list should not contains the field 'geometries'.", fieldList.contains("geometries"));
+                Assert.assertTrue("The field list should contains the field 'integers'.", fieldList.contains("integers"));
+
+                dataTypeList = new ArrayList<>();
+                excludedTypeList = new ArrayList<>();
+                excludedTypeList.add(DataType.GEOMETRY);
+                excludedTypeList.add(DataType.INTEGER);
+                fieldList = wpsServer.getTableFieldList("TABLE", dataTypeList, excludedTypeList);
+                Assert.assertFalse("The field list should not contains the field 'geometries'.", fieldList.contains("geometries"));
+                Assert.assertFalse("The field list should not contains the field 'integers'.", fieldList.contains("integers"));
+            } finally {
+                st.execute("DROP TABLE TABLE IF EXISTS");
+            }
+        }
+    }
+
+    @Test
+    public void testGetTableList() throws SQLException {
+        try(Statement st = connection.createStatement()) {
+            st.execute("DROP TABLE TABLE IF EXISTS");
+            try {
+                st.execute("CREATE TABLE TABLEINTEGER (\"integers\" integer)");
+                st.execute("CREATE TABLE TABLEGEOMETRY (\"geometries\" geometry)");
+                wpsServer.onDataManagerChange();
+
+                List<DataType> dataTypeList = new ArrayList<>();
+                List<DataType> excludedTypeList = new ArrayList<>();
+                List<String> tableList = wpsServer.getTableList(dataTypeList, excludedTypeList);
+                Assert.assertTrue("The table list should contains the table 'TABLEGEOMETRY'.", tableList.contains("TABLEGEOMETRY"));
+                Assert.assertTrue("The table list should contains the table 'TABLEINTEGER'.", tableList.contains("TABLEINTEGER"));
+
+                dataTypeList = new ArrayList<>();
+                dataTypeList.add(DataType.GEOMETRY);
+                excludedTypeList = new ArrayList<>();
+                tableList = wpsServer.getTableList(dataTypeList, excludedTypeList);
+                Assert.assertTrue("The table list should contains the table 'TABLEGEOMETRY'.", tableList.contains("TABLEGEOMETRY"));
+                Assert.assertFalse("The table list should not contains the table 'TABLEINTEGER'.", tableList.contains("TABLEINTEGER"));
+
+                dataTypeList = new ArrayList<>();
+                excludedTypeList = new ArrayList<>();
+                excludedTypeList.add(DataType.GEOMETRY);
+                tableList = wpsServer.getTableList(dataTypeList, excludedTypeList);
+                Assert.assertFalse("The table list should not contains the table 'TABLEGEOMETRY'.", tableList.contains("TABLEGEOMETRY"));
+                Assert.assertTrue("The table list should contains the table 'TABLEINTEGER'.", tableList.contains("TABLEINTEGER"));
+
+                dataTypeList = new ArrayList<>();
+                excludedTypeList = new ArrayList<>();
+                excludedTypeList.add(DataType.GEOMETRY);
+                excludedTypeList.add(DataType.INTEGER);
+                tableList = wpsServer.getTableList(dataTypeList, excludedTypeList);
+                Assert.assertFalse("The table list should not contains the table 'TABLEGEOMETRY'.", tableList.contains("TABLEGEOMETRY"));
+                Assert.assertFalse("The table list should not contains the table 'TABLEINTEGER'.", tableList.contains("TABLEINTEGER"));
+            } finally {
+                st.execute("DROP TABLE TABLE IF EXISTS");
+            }
+        }
+    }
+
+    private class CustomCoreWorkspace implements CoreWorkspace {
+
+        File applicationFolder = null;
+
+        @Override public String getApplicationFolder() {
+            if(applicationFolder == null) {
+                try {
+                    //Creates a directory in the temporary folder
+                    applicationFolder = File.createTempFile("temp", Long.toString(System.nanoTime()));
+                    if(!(applicationFolder.delete()))
+                    {
+                        return null;
+                    }
+
+                    if(!(applicationFolder.mkdir()))
+                    {
+                        return null;
+                    }
+                } catch (IOException e) {
+                    return null;
+                }
+            }
+            return applicationFolder.getAbsolutePath();
+        }
+
+        //Methods not used in the tests
+        @Override public String getJDBCConnectionReference() {return null;}
+        @Override public String getDataBaseUriFilePath() {return null;}
+        @Override public String getDataBaseUser() {return null;}
+        @Override public String getDataBasePassword() {return null;}
+        @Override public void setDataBaseUser(String user) {}
+        @Override public void setDataBasePassword(String password) {}
+        @Override public boolean isRequirePassword() {return false;}
+        @Override public void setRequirePassword(boolean requirePassword) {}
+        @Override public String getPluginCache() {return null;}
+        @Override public String getLogFile() {return null;}
+        @Override public String getLogPath() {return null;}
+        @Override public List<File> readKnownWorkspacesPath() {return null;}
+        @Override public File readDefaultWorkspacePath() {return null;}
+        @Override public String getTempFolder() {return null;}
+        @Override public String getPluginFolder() {return null;}
+        @Override public String getSourceFolder() {return null;}
+        @Override public String getWorkspaceFolder() {return null;}
+        @Override public void addPropertyChangeListener(PropertyChangeListener listener) {}
+        @Override public void addPropertyChangeListener(String prop, PropertyChangeListener listener) {}
+        @Override public void removePropertyChangeListener(PropertyChangeListener listener) {}
+        @Override public void removePropertyChangeListener(String prop, PropertyChangeListener listener) {}
+        @Override public int getVersionMajor() {return 0;}
+        @Override public int getVersionMinor() {return 0;}
+        @Override public int getVersionRevision() {return 0;}
+        @Override public String getVersionQualifier() {return null;}
+        @Override public String getDatabaseName() {return null;}
+        @Override public void setDatabaseName(String databaseName) {}
+    }
+}
+

--- a/bundles/wps/wps-service-orbisgis/src/test/java/org/orbisgis/wpsserviceorbisgis/OrbisGISWpsServerImplTest
+++ b/bundles/wps/wps-service-orbisgis/src/test/java/org/orbisgis/wpsserviceorbisgis/OrbisGISWpsServerImplTest
@@ -61,7 +61,7 @@ import java.util.List;
 /**
  * @author Sylvain PALOMINOS
  */
-public class JDBCUtilityTest {
+public class OrbisGISWpsServerImplTest {
     private static OrbisGISWpsServerImpl wpsServer;
     private static DataSource dataSource;
     private static Connection connection;
@@ -70,7 +70,7 @@ public class JDBCUtilityTest {
     public void init() throws Exception {
         wpsServer = new OrbisGISWpsServerImpl();
         dataSource = SFSUtilities.wrapSpatialDataSource(
-                H2GISDBFactory.createDataSource(JDBCUtilityTest.class.getSimpleName(), true));
+                H2GISDBFactory.createDataSource(OrbisGISWpsServerImplTest.class.getSimpleName(), true));
         connection = dataSource.getConnection();
         H2GISFunctions.registerFunction(connection.createStatement(), new DriverManager(), "");
         DataManager dataManager = new DataManagerImpl(dataSource);

--- a/bundles/wps/wps-service/src/main/java/org/orbisgis/wpsservice/model/DataType.java
+++ b/bundles/wps/wps-service/src/main/java/org/orbisgis/wpsservice/model/DataType.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.sql.Types;
 
 
 /**
@@ -194,6 +195,33 @@ public enum DataType {
             case MULTIPOLYGON:
                 return type == GeometryTypeCodes.MULTIPOLYGON;
             default: return false;
+        }
+    }
+
+    public static DataType getDataType(int sqlTypeId) {
+        switch (sqlTypeId) {
+            case Types.BOOLEAN:
+            case Types.BIT:
+                return BOOLEAN;
+            case Types.DOUBLE:
+                return DOUBLE;
+            case Types.NUMERIC:
+                return NUMBER;
+            case Types.DECIMAL:
+            case Types.REAL:
+            case Types.FLOAT:
+                return FLOAT;
+            case Types.BIGINT:
+            case Types.INTEGER:
+                return INTEGER;
+            case Types.SMALLINT:
+                return SHORT;
+            case Types.VARCHAR:
+            case Types.NCHAR:
+            case Types.CHAR:
+                return STRING;
+            default:
+                return OTHER;
         }
     }
 }


### PR DESCRIPTION
Fixes the issue #1197. Now the table list is loaded on opening a process in the toolbox. For that the table loading is done on a separated thread and a WaitLayer (like for the JDBCTableFieldValue) is running until it's done.