### PR TITLE
Licensing postgis-jts.

### DIFF
--- a/bundles/postgis-jts-osgi/pom.xml
+++ b/bundles/postgis-jts-osgi/pom.xml
@@ -12,6 +12,12 @@
     </parent>
     <description>OSGI bundle to load a PostGIS datasource factory that uses JTS objets</description>
     <url>http://www.orbisgis.org</url>
+    <licenses>
+        <license>
+            <name>GNU Lesser General Public License (LGPLV3+)</name>
+            <url>http://www.gnu.org/licenses/lgpl-3.0.html</url>
+        </license>
+    </licenses>
     <build>
         <plugins>
             <plugin>

--- a/bundles/postgis-jts/pom.xml
+++ b/bundles/postgis-jts/pom.xml
@@ -12,6 +12,12 @@
     <description>JTS wrapper on a PostGIS jdbc connection</description>
     <url>http://www.orbisgis.org</url>
     <packaging>bundle</packaging>
+    <licenses>
+        <license>
+            <name>GNU Lesser General Public License (LGPLV3+)</name>
+            <url>http://www.gnu.org/licenses/lgpl-3.0.html</url>
+        </license>
+    </licenses>
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Changes the license of postgis-jts and postgis-jts-osgi from GPL3 to LGPL3. Linked to the issue orbisgis/h2gis#802