### PR TITLE
Fix lost selection

### DIFF
--- a/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/TableEditor.java
+++ b/bundles/table-editor/src/main/java/org/orbisgis/tablegui/impl/TableEditor.java
@@ -284,7 +284,15 @@ public class TableEditor extends JPanel implements EditorDockable, SourceTable,T
         if (tableEditableElement.isFiltered()) {
             onMenuFilterRows();
         } else {
+            //Save the selection
+            IntegerUnion selection = getTableModelSelection(0);
+            //Clear the filter
             onMenuClearFilter();
+            //Load the selection
+            List<Integer> ranges = selection.getValueRanges();
+            for(int i=0; i<ranges.size(); i+=2){
+                table.addRowSelectionInterval(ranges.get(i), ranges.get(i+1));
+            }
         }
     }
 


### PR DESCRIPTION
In the TableEditor the selection isn't lost after removing the filter. Issue #1130 