### PR TITLE
Fix Info tool with ProgressMonitor

### DIFF
--- a/bundles/map-editor/src/main/java/org/orbisgis/mapeditor/map/MapEditor.java
+++ b/bundles/map-editor/src/main/java/org/orbisgis/mapeditor/map/MapEditor.java
@@ -494,7 +494,7 @@ public class MapEditor extends JPanel implements TransformListener, MapEditorExt
         actions.addAction(new ActionAutomaton(MapEditorAction.A_PAN,new PanTool(),this).setLogicalGroup("navigation"));
        
         // Selection tools
-        actions.addAction(new ActionAutomaton(MapEditorAction.A_INFO_TOOL,new InfoTool(editorManager),this)
+        actions.addAction(new ActionAutomaton(MapEditorAction.A_INFO_TOOL,new InfoTool(editorManager, executorService),this)
                 .addTrackedMapContextProperty(MapContext.PROP_SELECTEDLAYERS)
                 .addTrackedMapContextProperty(MapContext.PROP_SELECTEDSTYLES).setLogicalGroup("selection"));
         


### PR DESCRIPTION
Adds a ProgressMonitor to the info tool. When an other selection is done, the first one is cancelled and the second is run. Issue #1131  