### PR TITLE
Linked tables

### DIFF
--- a/bundles/geocatalog/src/main/java/org/orbisgis/geocatalog/impl/SourceListModel.java
+++ b/bundles/geocatalog/src/main/java/org/orbisgis/geocatalog/impl/SourceListModel.java
@@ -76,7 +76,8 @@ public class SourceListModel extends AbstractListModel<ContainerItemProperties> 
     private static final I18n I18N = I18nFactory.getI18n(SourceListModel.class);
     private static final Logger LOGGER = LoggerFactory.getLogger(SourceListModel.class);
     private static final long serialVersionUID = 1L;
-    private static final String[] SHOWN_TABLE_TYPES = new String[]{"TABLE", "SYSTEM TABLE","LINKED TABLE","VIEW", "EXTERNAL"};
+    private static final String[] SHOWN_TABLE_TYPES = new String[]{"TABLE", "SYSTEM TABLE","LINKED TABLE","VIEW",
+            "EXTERNAL", "TABLE LINK"};
     /** Non filtered tables */
     private List<Map<IFilter.ATTRIBUTES, String>> allTables = new ArrayList<>();
     /** Filtered tables */

--- a/bundles/map-editor/src/main/java/org/orbisgis/mapeditor/map/CachedResultSetContainer.java
+++ b/bundles/map-editor/src/main/java/org/orbisgis/mapeditor/map/CachedResultSetContainer.java
@@ -105,7 +105,14 @@ public class CachedResultSetContainer implements ResultSetProviderFactory {
                     readRowSet = layer.getDataManager().createReadRowSet();
                     // If the used PK is hidden (because it is system pk)
                     if(integerPK.isEmpty()) {
-                        readRowSet.setCommand("SELECT " + defaultResultSetProvider.getPkName() + ", * FROM "+tableRef);
+                        String defaultPk = defaultResultSetProvider.getPkName();
+                        if(defaultPk.isEmpty()) {
+                            LOGGER.warn(I18N.tr("Unable to find a PrimaryKey for the table {0}.", tableRef));
+                            readRowSet.setCommand("SELECT * FROM " + tableRef);
+                        }
+                        else{
+                            readRowSet.setCommand("SELECT " + defaultPk + ", * FROM " + tableRef);
+                        }
                     }
                     readRowSet.setFetchSize(FETCH_SIZE);
                     readRowSet.setCloseDelay(ROWSET_FREE_DELAY);


### PR DESCRIPTION
Adds a workaround to avoid the error get with linked table in h2 which have no PK and _ROWID_.
Fixes the display of liked tables in the geocatalog.
Linked to the issue #1245