### PR TITLE
Adds the orbisgis version plugin filter

### DIFF
--- a/bundles/core-export/pom.xml
+++ b/bundles/core-export/pom.xml
@@ -35,6 +35,7 @@
                 <configuration>
                     <instructions>
                         <Public-Package>org.orbisgis.core_export.*</Public-Package>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/bundles/core-jdbc/pom.xml
+++ b/bundles/core-jdbc/pom.xml
@@ -30,6 +30,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-Vendor>Lab-STICC - CNRS UMR 6285</Bundle-Vendor>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/bundles/core-map/pom.xml
+++ b/bundles/core-map/pom.xml
@@ -36,6 +36,7 @@
                     <instructions>
                         <Public-Package>org.orbisgis.coremap.*</Public-Package>
                         <Private-Package>org.orbisgis.coremap.translation</Private-Package>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/bundles/dbjobs/pom.xml
+++ b/bundles/dbjobs/pom.xml
@@ -36,6 +36,7 @@
                     <instructions>
                         <Public-Package>org.orbisgis.dbjobs.api</Public-Package>
                         <Private-Package>org.orbisgis.dbjobs.*</Private-Package>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/bundles/editor-jdbc/pom.xml
+++ b/bundles/editor-jdbc/pom.xml
@@ -17,6 +17,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-Vendor>Lab-STICC - CNRS UMR 6285</Bundle-Vendor>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/bundles/geocatalog-tree/pom.xml
+++ b/bundles/geocatalog-tree/pom.xml
@@ -36,6 +36,7 @@
                     <instructions>
                         <Public-Package>org.orbisgis.geocatalogtree.api</Public-Package>
                         <Private-Package>org.orbisgis.geocatalogtree.*</Private-Package>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/bundles/geocatalog/pom.xml
+++ b/bundles/geocatalog/pom.xml
@@ -36,6 +36,7 @@
                     <instructions>
                         <Public-Package>org.orbisgis.geocatalog.api</Public-Package>
                         <Private-Package>org.orbisgis.geocatalog.*</Private-Package>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/bundles/h2trigger-osgi/pom.xml
+++ b/bundles/h2trigger-osgi/pom.xml
@@ -36,6 +36,7 @@
                     <instructions>
                         <Bundle-Vendor>Lab-STICC - CNRS UMR 6285</Bundle-Vendor>
                         <Private-Package>org.orbisgis.h2triggersosgi.*</Private-Package>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/bundles/h2trigger/pom.xml
+++ b/bundles/h2trigger/pom.xml
@@ -23,6 +23,7 @@
                     <instructions>
                         <Fragment-Host>org.h2</Fragment-Host>
                         <Import-Package>!org.h2.*,*</Import-Package>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/bundles/log-file-writer/pom.xml
+++ b/bundles/log-file-writer/pom.xml
@@ -35,6 +35,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-Vendor>Lab-STICC - CNRS UMR 6285</Bundle-Vendor>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/bundles/log-panel/pom.xml
+++ b/bundles/log-panel/pom.xml
@@ -36,6 +36,7 @@
                 <configuration>
                     <instructions>
                         <Private-Package>org.orbisgis.logpanel.*</Private-Package>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/bundles/map-editor-api/pom.xml
+++ b/bundles/map-editor-api/pom.xml
@@ -21,6 +21,7 @@
                 <configuration>
                     <instructions>
                         <Public-Package>org.orbisgis.mapeditorapi.*</Public-Package>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/bundles/map-editor/pom.xml
+++ b/bundles/map-editor/pom.xml
@@ -35,6 +35,7 @@
                 <configuration>
                     <instructions>
                         <Private-Package>org.orbisgis.mapeditor.*</Private-Package>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/bundles/orbisgis-omanager-plugin/pom.xml
+++ b/bundles/orbisgis-omanager-plugin/pom.xml
@@ -34,6 +34,7 @@
                                                 <Bundle-Vendor>Lab-STICC - CNRS UMR 6285</Bundle-Vendor>
                                                 <Bundle-Icon>icon.png;size=32</Bundle-Icon>
                                                 <Bundle-Category>gui</Bundle-Category>
+                                                <OrbisGIS-Version>5.1</OrbisGIS-Version>
                                         </instructions>
                                 </configuration>
                         </plugin>

--- a/bundles/orbisgis-omanager/pom.xml
+++ b/bundles/orbisgis-omanager/pom.xml
@@ -33,6 +33,7 @@
                                                 <Bundle-Vendor>Lab-STICC - CNRS UMR 6285</Bundle-Vendor>
                                                 <Bundle-Category>gui</Bundle-Category>
                                                 <Import-Service>org.osgi.service.obr.RepositoryAdmin</Import-Service>
+                                                <OrbisGIS-Version>5.1</OrbisGIS-Version>
                                         </instructions>
                                 </configuration>
                         </plugin>

--- a/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/MainPluginPanel.java
+++ b/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/MainPluginPanel.java
@@ -36,6 +36,7 @@
  */
 package org.orbisgis.omanager.ui;
 
+import org.orbisgis.frameworkapi.CoreWorkspace;
 import org.orbisgis.omanager.plugin.api.CustomPlugin;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.*;
@@ -64,5 +65,13 @@ public class MainPluginPanel extends MainPanel {
     }
 
     public void unsetExecutorService(ExecutorService executorService) {
+    }
+
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
+    public void setCoreWorkspace(CoreWorkspace coreWorkspace) {
+        super.setCoreWorkspace(coreWorkspace);
+    }
+
+    public void unsetCoreWorkspace(CoreWorkspace coreWorkspace) {
     }
 }

--- a/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/MainSystemPanel.java
+++ b/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/MainSystemPanel.java
@@ -36,6 +36,7 @@
  */
 package org.orbisgis.omanager.ui;
 
+import org.orbisgis.frameworkapi.CoreWorkspace;
 import org.orbisgis.omanager.plugin.api.CustomPlugin;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.*;
@@ -64,5 +65,13 @@ public class MainSystemPanel extends MainPanel {
     }
 
     public void unsetExecutorService(ExecutorService executorService) {
+    }
+
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
+    public void setCoreWorkspace(CoreWorkspace coreWorkspace) {
+        super.setCoreWorkspace(coreWorkspace);
+    }
+
+    public void unsetCoreWorkspace(CoreWorkspace coreWorkspace) {
     }
 }

--- a/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/MainWpsPluginPanel.java
+++ b/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/MainWpsPluginPanel.java
@@ -36,6 +36,7 @@
  */
 package org.orbisgis.omanager.ui;
 
+import org.orbisgis.frameworkapi.CoreWorkspace;
 import org.orbisgis.omanager.plugin.api.CustomPlugin;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.*;
@@ -64,5 +65,13 @@ public class MainWpsPluginPanel extends MainPanel {
     }
 
     public void unsetExecutorService(ExecutorService executorService) {
+    }
+
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
+    public void setCoreWorkspace(CoreWorkspace coreWorkspace) {
+        super.setCoreWorkspace(coreWorkspace);
+    }
+
+    public void unsetCoreWorkspace(CoreWorkspace coreWorkspace) {
     }
 }

--- a/bundles/postgis-jts-osgi/pom.xml
+++ b/bundles/postgis-jts-osgi/pom.xml
@@ -33,6 +33,7 @@
                         <Embed-Dependency>postgresql;postgis-jdbc;postgis-jdbc-jtsparser;scope=compile;inline=true</Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
                         <_exportcontents>org.postgresql.*;org.postgis.*</_exportcontents>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/bundles/postgis-jts/pom.xml
+++ b/bundles/postgis-jts/pom.xml
@@ -29,6 +29,7 @@
                     <instructions>
                         <Fragment-Host>org.h2</Fragment-Host>
                         <Import-Package>!org.h2.*,*</Import-Package>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/bundles/sql-parser-api/pom.xml
+++ b/bundles/sql-parser-api/pom.xml
@@ -21,6 +21,7 @@
                 <configuration>
                     <instructions>
                         <Public-Package>org.orbisgis.sql-parser-api.*</Public-Package>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/bundles/sqlconsole-parser/pom.xml
+++ b/bundles/sqlconsole-parser/pom.xml
@@ -35,6 +35,7 @@
                 <configuration>
                     <instructions>
                         <Private-Package>org.orbisgis.scp.*</Private-Package>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/bundles/sqlconsole/pom.xml
+++ b/bundles/sqlconsole/pom.xml
@@ -36,6 +36,7 @@
                     <instructions>
                         <Private-Package>org.orbisgis.sqlconsole.*</Private-Package>
                         <Embed-Dependency>markdown4j</Embed-Dependency>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/bundles/table-editor-api/pom.xml
+++ b/bundles/table-editor-api/pom.xml
@@ -20,6 +20,7 @@
                 <configuration>
                     <instructions>
                         <Public-Package>org.orbisgis.tableeditorapi.*</Public-Package>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/bundles/table-editor/pom.xml
+++ b/bundles/table-editor/pom.xml
@@ -35,6 +35,7 @@
                 <configuration>
                     <instructions>
                         <Private-Package>org.orbisgis.tablegui.*</Private-Package>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/bundles/toc-api/pom.xml
+++ b/bundles/toc-api/pom.xml
@@ -19,6 +19,11 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <version>2.3.7</version>
                 <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
+                    </instructions>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/bundles/toc/pom.xml
+++ b/bundles/toc/pom.xml
@@ -35,6 +35,7 @@
                     <instructions>
                         <Private-Package>org.orbisgis.view.toc.translation.*</Private-Package>
                         <Public-Package>org.orbisgis.view.toc.*</Public-Package>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/bundles/toolbox-editor/pom.xml
+++ b/bundles/toolbox-editor/pom.xml
@@ -41,6 +41,7 @@
                     <instructions>
                         <Private-Package>org.orbisgis.toolboxeditor.*</Private-Package>
                         <Bundle-Category>OrbisGIS,WPS</Bundle-Category>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/docking-impl/pom.xml
+++ b/docking-impl/pom.xml
@@ -43,6 +43,7 @@
                         <Embed-Transitive>true</Embed-Transitive>
                         <_exportcontents>bibliothek.gui.*, data.bibliothek.gui.*</_exportcontents>
                         <Import-Package>!com.sun.awt.*, *</Import-Package>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/external/itextpdf/pom.xml
+++ b/external/itextpdf/pom.xml
@@ -27,6 +27,7 @@
                         <Bundle-Version>${itext-version}</Bundle-Version>
                         <_exportcontents>com.itextpdf.text.*</_exportcontents>
                         <Import-Package>!org.bouncycastle.*, *</Import-Package>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/external/jai/pom.xml
+++ b/external/jai/pom.xml
@@ -26,6 +26,7 @@
                         <Bundle-Version>1.1.3</Bundle-Version>
                         <_exportcontents>com.sun.media.jai.*, javax.media.jai.*</_exportcontents>
                         <Import-Package>!com.sun.image.*,!sun.security.action.*,!com.sun.medialib.*,!sun.awt.image.*, *</Import-Package>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/external/json-simple-osgi/pom.xml
+++ b/external/json-simple-osgi/pom.xml
@@ -26,6 +26,7 @@
                         <Embed-Transitive>true</Embed-Transitive>
                         <Bundle-Version>${json-simple-version}</Bundle-Version>
                         <_exportcontents>org.json.simple,org.json.simple.*</_exportcontents>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/external/jts-core-osgi/pom.xml
+++ b/external/jts-core-osgi/pom.xml
@@ -26,6 +26,7 @@
                         <Embed-Transitive>true</Embed-Transitive>
                         <Bundle-Version>${jts-core-version}</Bundle-Version>
                         <_exportcontents>com.vividsolutions.jts,com.vividsolutions.jts.*</_exportcontents>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/external/jts-io-osgi/pom.xml
+++ b/external/jts-io-osgi/pom.xml
@@ -26,6 +26,7 @@
                         <Embed-Transitive>true</Embed-Transitive>
                         <Bundle-Version>${jts-io-version}</Bundle-Version>
                         <_exportcontents>com.vividsolutions.jts,com.vividsolutions.jts.*</_exportcontents>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/external/jts-osgi/pom.xml
+++ b/external/jts-osgi/pom.xml
@@ -25,6 +25,7 @@
                         <Embed-Transitive>true</Embed-Transitive>
                         <Bundle-Version>${jts-version}</Bundle-Version>
                         <_exportcontents>com.vividsolutions.jts,com.vividsolutions.jts.*</_exportcontents>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/external/mig-layout/pom.xml
+++ b/external/mig-layout/pom.xml
@@ -27,6 +27,7 @@
                         <Embed-Transitive>true</Embed-Transitive>
                         <Bundle-Version>${miglayout-version}</Bundle-Version>
                         <_exportcontents>net.miginfocom.swing.*,net.miginfocom.layout.*</_exportcontents>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/external/rsyntax-language-support/pom.xml
+++ b/external/rsyntax-language-support/pom.xml
@@ -27,6 +27,7 @@
                         <Bundle-Version>${rsyntax-version}</Bundle-Version>
                         <_exportcontents>org.fife.rsta.ac.*</_exportcontents>
                         <Import-Package>org.mozilla.javascript;resolution:=optional,org.mozilla.javascript.ast;resolution:=optional, *</Import-Package>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/external/rsyntax-osgi/pom.xml
+++ b/external/rsyntax-osgi/pom.xml
@@ -28,6 +28,7 @@
                         <Bundle-Version>${rsyntax-version}</Bundle-Version>
                         <_exportcontents>org.fife.*</_exportcontents>
                         <Import-Package>org.pushingpixels.substance.api.renderers;resolution:=optional, *</Import-Package>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/external/svg-salamander/pom.xml
+++ b/external/svg-salamander/pom.xml
@@ -27,6 +27,7 @@
                         <Bundle-Version>1.0</Bundle-Version>
                         <_exportcontents>com.kitfox.svg.*</_exportcontents>
                         <Import-Package>!org.apache.tools.ant.*,!sun.misc.*, *</Import-Package>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -22,6 +22,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-Vendor>Lab-STICC CNRS UMR 6285</Bundle-Vendor>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/legend/pom.xml
+++ b/legend/pom.xml
@@ -51,6 +51,7 @@
                                 <Public-Package>org.orbisgis.legend.*</Public-Package>
                                 <Private-Package>org.orbisgis.legend.translation</Private-Package>
                                 <Import-Package>javax.swing.event, *</Import-Package>
+                                <OrbisGIS-Version>5.1</OrbisGIS-Version>
                             </instructions>
                         </configuration>
                     </plugin>

--- a/main-frame/pom.xml
+++ b/main-frame/pom.xml
@@ -35,6 +35,7 @@
                 <configuration>
                     <instructions>
                         <Private-Package>org.orbisgis.mainframe.*</Private-Package>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/orbisgis-commons/pom.xml
+++ b/orbisgis-commons/pom.xml
@@ -50,6 +50,7 @@
                     <instructions>
                         <Public-Package>org.orbisgis.commons.*</Public-Package>
                         <Private-Package>org.orbisgis.commons</Private-Package>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/orbisgis-sif/pom.xml
+++ b/orbisgis-sif/pom.xml
@@ -26,6 +26,7 @@
                                 <instructions>
                                     <Bundle-Vendor>Lab-STICC CNRS UMR 6285</Bundle-Vendor>
                                     <Bundle-Category>gui</Bundle-Category>
+                                    <OrbisGIS-Version>5.1</OrbisGIS-Version>
                                 </instructions>
                             </configuration>
                         </plugin>

--- a/progress-gui/pom.xml
+++ b/progress-gui/pom.xml
@@ -36,6 +36,7 @@
                     <instructions>
                         <Private-Package>org.orbisgis.progressgui.*</Private-Package>
                         <Import-Package>!sun.awt, *</Import-Package>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/wms-client/pom.xml
+++ b/wms-client/pom.xml
@@ -58,6 +58,11 @@
 						</goals>
 					</execution>
 				</executions>
+				<configuration>
+					<instructions>
+						<OrbisGIS-Version>5.1</OrbisGIS-Version>
+					</instructions>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/workspace-gui-api/pom.xml
+++ b/workspace-gui-api/pom.xml
@@ -22,6 +22,7 @@
                 <configuration>
                     <instructions>
                         <Public-Package>org.orbisgis.wkguiapi.*</Public-Package>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>

--- a/workspace-gui/pom.xml
+++ b/workspace-gui/pom.xml
@@ -35,6 +35,7 @@
                 <configuration>
                     <instructions>
                         <Private-Package>org.orbisgis.wkgui.*</Private-Package>
+                        <OrbisGIS-Version>5.1</OrbisGIS-Version>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
In the plugin manager the bundle are by default filtered by compatible orbisgis version.  Linked to the issue #1262.