### PR TITLE
Default to display only compatible plugins

### DIFF
--- a/bundles/orbisgis-omanager-plugin/src/main/java/org/orbisgis/omanager/plugin/api/DownloadOBRProcess.java
+++ b/bundles/orbisgis-omanager-plugin/src/main/java/org/orbisgis/omanager/plugin/api/DownloadOBRProcess.java
@@ -1,4 +1,4 @@
-package org.orbisgis.omanager.plugin.impl;
+package org.orbisgis.omanager.plugin.api;
 
 import org.orbisgis.commons.progress.SwingWorkerPM;
 import org.orbisgis.omanager.plugin.api.RepositoryPluginHandler;

--- a/bundles/orbisgis-omanager-plugin/src/main/java/org/orbisgis/omanager/plugin/api/Plugin.java
+++ b/bundles/orbisgis-omanager-plugin/src/main/java/org/orbisgis/omanager/plugin/api/Plugin.java
@@ -1,0 +1,4 @@
+package org.orbisgis.omanager.plugin.api;
+
+public interface Plugin {
+}

--- a/bundles/orbisgis-omanager-plugin/src/main/java/org/orbisgis/omanager/plugin/api/RepositoryPluginHandler.java
+++ b/bundles/orbisgis-omanager-plugin/src/main/java/org/orbisgis/omanager/plugin/api/RepositoryPluginHandler.java
@@ -1,0 +1,36 @@
+package org.orbisgis.omanager.plugin.api;
+
+import org.orbisgis.commons.progress.ProgressMonitor;
+import org.osgi.service.obr.Repository;
+
+import java.beans.PropertyChangeSupport;
+import java.net.URL;
+import java.util.Collection;
+import java.util.List;
+
+public interface RepositoryPluginHandler {
+
+    Collection<Repository> getRepositories();
+    List<URL> getRepositoriesURL();
+    /**
+     * @return Parsed resource information on the repository XML.
+     */
+    Collection<Plugin> getResources();
+
+
+    /**
+     * Add or remove listener on repository updates.
+     * @return
+     */
+    PropertyChangeSupport getPropertyChangeSupport();
+
+
+    /**
+     * Reload the list of resource by downloading and parsing all repositories XML again.
+     */
+    void refresh(ProgressMonitor pm);
+
+    void addRepository(URL repository);
+
+    boolean removeRepository(URL repository);
+}

--- a/bundles/orbisgis-omanager-plugin/src/main/java/org/orbisgis/omanager/plugin/impl/DownloadOBRProcess.java
+++ b/bundles/orbisgis-omanager-plugin/src/main/java/org/orbisgis/omanager/plugin/impl/DownloadOBRProcess.java
@@ -1,0 +1,23 @@
+package org.orbisgis.omanager.plugin.impl;
+
+import org.orbisgis.commons.progress.SwingWorkerPM;
+import org.orbisgis.omanager.plugin.api.RepositoryPluginHandler;
+
+public class DownloadOBRProcess extends SwingWorkerPM {
+    RepositoryPluginHandler remotePlugins;
+
+    public DownloadOBRProcess(RepositoryPluginHandler remotePlugins) {
+        this.remotePlugins = remotePlugins;
+    }
+
+    @Override
+    protected Object doInBackground() throws Exception {
+        remotePlugins.refresh(getProgressMonitor());
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return "MainPanel#DownloadOBRProcess";
+    }
+}

--- a/bundles/orbisgis-omanager-plugin/src/main/java/org/orbisgis/omanager/plugin/impl/ManagerMenuFactory.java
+++ b/bundles/orbisgis-omanager-plugin/src/main/java/org/orbisgis/omanager/plugin/impl/ManagerMenuFactory.java
@@ -57,6 +57,7 @@ import javax.swing.ImageIcon;
 import org.orbisgis.mainframe.api.MainFrameAction;
 import org.orbisgis.mainframe.api.MainWindow;
 import org.orbisgis.omanager.plugin.api.CustomPlugin;
+import org.orbisgis.omanager.plugin.api.DownloadOBRProcess;
 import org.orbisgis.omanager.plugin.api.RepositoryPluginHandler;
 import org.orbisgis.sif.components.actions.DefaultAction;
 import org.osgi.framework.BundleContext;

--- a/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/BundleItem.java
+++ b/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/BundleItem.java
@@ -61,6 +61,7 @@ public class BundleItem {
     private static final int MAX_SHORT_DESCRIPTION_CHAR_COUNT = 50;
     private String shortDesc;
     private Resource obrResource;      // only if a remote bundle is available
+    private boolean obrResolve;        // If this plugin can be resolved
     private long bundleId = -1;        // Bundle id
     private BundleContext bundleContext;
     private static final Long KILO = 1024L;
@@ -141,8 +142,16 @@ public class BundleItem {
     /**
      * @param obrResource OSGi bundle repository resource reference. (remote bundle)
      */
-    public void setObrResource(Resource obrResource) {
+    public void setObrResource(Resource obrResource, boolean obrResolve) {
         this.obrResource = obrResource;
+        this.obrResolve = obrResolve;
+    }
+
+    /**
+     * @return True if the remote plugin could be downloaded and resolved
+     */
+    public boolean isBundleCompatible() {
+        return obrResolve;
     }
 
     /**

--- a/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/BundleItem.java
+++ b/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/BundleItem.java
@@ -44,6 +44,8 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+
+import org.orbisgis.omanager.plugin.api.Plugin;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
@@ -56,7 +58,7 @@ import org.xnap.commons.i18n.I18nFactory;
  * A bundle that can be installed from local or/and on remote repository.
  * @author Nicolas Fortin
  */
-public class BundleItem {
+public class BundleItem implements Plugin {
     private static final I18n I18N = I18nFactory.getI18n(BundleItem.class);
     private static final int MAX_SHORT_DESCRIPTION_CHAR_COUNT = 50;
     private String shortDesc;
@@ -151,7 +153,7 @@ public class BundleItem {
      * @return True if the remote plugin could be downloaded and resolved
      */
     public boolean isBundleCompatible() {
-        return obrResolve;
+        return obrResolve || obrResource == null;
     }
 
     /**

--- a/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/BundleListModel.java
+++ b/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/BundleListModel.java
@@ -79,7 +79,7 @@ public class BundleListModel extends AbstractListModel<BundleItem> {
         this.bundleContext = bundleContext;
         this.remotePlugins = remotePlugins;
         this.remotePlugins.getPropertyChangeSupport().
-                addPropertyChangeListener(EventHandler.create(PropertyChangeListener.class,this,"update"));
+                addPropertyChangeListener(RepositoryAdminTracker.PROP_RESOURCES, EventHandler.create(PropertyChangeListener.class,this,"update"));
     }
 
     /**
@@ -111,10 +111,24 @@ public class BundleListModel extends AbstractListModel<BundleItem> {
         fireIntervalRemoved(this, index,index);
     }
 
+    public void update() {
+        if(SwingUtilities.isEventDispatchThread()) {
+            doupdate();
+        } else {
+            SwingUtilities.invokeLater(new Runnable() {
+                @Override
+                public void run() {
+                    doupdate();
+                }
+            });
+        }
+
+    }
+
     /**
      * Update the content of the bundle context. Called also by the propertyChangeListener.
      */
-    public void update() {
+    private void doupdate() {
         Map<String,BundleItem> curBundles = new HashMap<>(storedBundles.size());
         for(BundleItem bundle : storedBundles) {
             curBundles.put(bundle.getSymbolicName(),bundle);

--- a/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/BundleListModel.java
+++ b/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/BundleListModel.java
@@ -47,6 +47,9 @@ import java.util.Map;
 import java.util.Set;
 import javax.swing.AbstractListModel;
 import javax.swing.SwingUtilities;
+
+import org.orbisgis.omanager.plugin.api.Plugin;
+import org.orbisgis.omanager.plugin.api.RepositoryPluginHandler;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleEvent;
@@ -62,20 +65,20 @@ public class BundleListModel extends AbstractListModel<BundleItem> {
     private List<BundleItem> storedBundles = new ArrayList<>();
     private BundleContext bundleContext;
     private BundleListener bundleListener = new BundleModelListener();
-    private RepositoryAdminTracker repositoryAdminTrackerCustomizer;
+    private RepositoryPluginHandler remotePlugins;
     // Hidden bundles
     private final static Set<String> HIDDEN_BUNDLES_SET =
-            new HashSet<>(Arrays.asList(new String[]{"org.apache.felix.framework",
-            "org.apache.felix.shell","org.osgi.service.obr","org.apache.felix.shell.gui",
-            "org.apache.felix.bundlerepository","org.orbisgis.omanager-plugin",
-            "org.orbisgis.omanager"}));
+            new HashSet<>(Arrays.asList("org.apache.felix.framework",
+                    "org.apache.felix.shell","org.osgi.service.obr","org.apache.felix.shell.gui",
+                    "org.apache.felix.bundlerepository","org.orbisgis.omanager-plugin",
+                    "org.orbisgis.omanager"));
     /**
      * @param bundleContext Bundle context to track.
      */
-    public BundleListModel(BundleContext bundleContext, RepositoryAdminTracker repositoryAdminTrackerCustomizer) {
+    public BundleListModel(BundleContext bundleContext, RepositoryPluginHandler remotePlugins) {
         this.bundleContext = bundleContext;
-        this.repositoryAdminTrackerCustomizer = repositoryAdminTrackerCustomizer;
-        repositoryAdminTrackerCustomizer.getPropertyChangeSupport().
+        this.remotePlugins = remotePlugins;
+        this.remotePlugins.getPropertyChangeSupport().
                 addPropertyChangeListener(EventHandler.create(PropertyChangeListener.class,this,"update"));
     }
 
@@ -159,10 +162,11 @@ public class BundleListModel extends AbstractListModel<BundleItem> {
         }
         // Remove all stored resources
         for(BundleItem item : storedBundles) {
-            item.setObrResource(null);
+            item.setObrResource(null, false);
         }
         // Fetch cached repositories bundles
-        for(Resource resource : repositoryAdminTrackerCustomizer.getResources()) {
+        for(Plugin plugin : new ArrayList<>(remotePlugins.getResources())) {
+            BundleItem resource = (BundleItem) plugin;
             if(!HIDDEN_BUNDLES_SET.contains(resource.getSymbolicName())) {
                 BundleItem storedBundle = curBundles.get(getIdentifier(resource));
                 if(storedBundle!=null) {
@@ -171,16 +175,14 @@ public class BundleListModel extends AbstractListModel<BundleItem> {
                     if(storedObrResource==null || storedObrResource.getVersion()
                             .compareTo(resource.getVersion())<0) {
                         // Replace stored Obr Resource if the version is inferior or it does not exist
-                        storedBundle.setObrResource(resource);
+                        storedBundle.setObrResource(resource.getObrResource(), resource.isBundleCompatible());
                         int index = storedBundles.indexOf(storedBundle);
                         fireContentsChanged(this,index,index);
                     }
                 } else {
-                    BundleItem newBundle = new BundleItem(bundleContext);
-                    newBundle.setObrResource(resource);
-                    curBundles.put(getIdentifier(resource),newBundle);
+                    curBundles.put(getIdentifier(resource),resource);
                     int index = storedBundles.size();
-                    storedBundles.add(newBundle);
+                    storedBundles.add(resource);
                     fireIntervalAdded(this, index, index);
                 }
             }

--- a/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/ItemFilterStatusFactory.java
+++ b/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/ItemFilterStatusFactory.java
@@ -45,17 +45,10 @@ import org.osgi.framework.Version;
  * @author Nicolas Fortin
  */
 public class ItemFilterStatusFactory {
-
-    private static final String ORBISGIS_VERSION = "OrbisGIS-Version";
-
     private Installed installed = new Installed();
     private Available available = new Available();
 
     public ItemFilterStatusFactory() {}
-
-    public void setVersion(String version){
-        available.setVersion(version);
-    }
 
     public enum Status { ALL, INSTALLED, UPDATE, AVAILABLE }
 
@@ -78,36 +71,9 @@ public class ItemFilterStatusFactory {
     }
 
     private class Available implements ItemFilter<BundleListModel> {
-        private String version;
-        public void setVersion(String version){
-            this.version = version;
-        }
-
         @Override
         public boolean include(BundleListModel model, int elementId) {
-            Bundle bundle = model.getBundle(elementId).getBundle();
-            if(bundle != null){
-                String bVersion = bundle.getHeaders().get(ORBISGIS_VERSION);
-                if(bVersion != null && version != null) {
-
-                    Version versionOrbisgis = new Version(version);
-                    String[] versionSplit = bVersion.split(",");
-                    for(String str : versionSplit){
-                        if(str.contains("-")){
-                            int diff1 = new Version(str.split("-")[0]).compareTo(versionOrbisgis);
-                            int diff2 = new Version(str.split("-")[1]).compareTo(versionOrbisgis);
-                            if((diff1>=0 && diff2<=0) || (diff1<=0 && diff2>=0)){
-                                return true;
-                            }
-                        }else{
-                            if(new Version(str).equals(versionOrbisgis)){
-                                return true;
-                            }
-                        }
-                    }
-                }
-            }
-            return true;
+            return model.getBundle(elementId).isBundleCompatible();
         }
     }
 }

--- a/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/MainPanel.java
+++ b/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/MainPanel.java
@@ -81,6 +81,7 @@ import javax.swing.text.Document;
 import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.StyleConstants;
 
+import org.orbisgis.commons.progress.SwingWorkerPM;
 import org.orbisgis.frameworkapi.CoreWorkspace;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -151,10 +152,6 @@ public class MainPanel extends JPanel implements CustomPlugin {
      */
     public void setExecutorService(ExecutorService executorService){
         this.executorService = executorService;
-    }
-
-    public void setCoreWorkspace(CoreWorkspace coreWorkspace){
-        itemFilterStatusFactory.setVersion(coreWorkspace.getVersionMajor()+"."+coreWorkspace.getVersionMinor());
     }
 
     /**
@@ -398,7 +395,7 @@ public class MainPanel extends JPanel implements CustomPlugin {
         if(!filterTextValue.isEmpty()) {
             filters.add(new ItemFilterContains(filterTextValue));
         }
-        if(filters.size()>=1) {
+        if(filters.size()>1) {
             filterModel.setFilter(new ItemFilterAndGroup(filters));
         } else if(filters.size()==1) {
             filterModel.setFilter(filters.get(0));
@@ -440,6 +437,7 @@ public class MainPanel extends JPanel implements CustomPlugin {
     public void onFilterByBundleCategory() {
         applyFilters();
     }
+
     /**
      * User click on "Refresh" button.
      */
@@ -447,6 +445,7 @@ public class MainPanel extends JPanel implements CustomPlugin {
         DownloadOBRProcess reloadAction = new DownloadOBRProcess();
         reloadAction.execute();
     }
+
     public void onAddBundleJarUri() {
         String errMessage = "";
         String chosenURL = "";
@@ -586,7 +585,7 @@ public class MainPanel extends JPanel implements CustomPlugin {
         radioBar.setLayout(new BoxLayout(radioBar, BoxLayout.X_AXIS));
         // Create radio buttons
         ButtonGroup filterGroup = new ButtonGroup();
-        createRadioButton(I18N.tr("Available"), I18N.tr("Show only the available bundles."), true,
+        createRadioButton(I18N.tr("Compatible"), I18N.tr("Show only plugins compatible with this version of OrbisGIS."), true,
                 "onFilterBundleAvailable", filterGroup, radioBar);
         createRadioButton(I18N.tr("Installed"),I18N.tr("Show only installed bundles."),false,"onFilterBundleInstall",
                 filterGroup, radioBar);
@@ -690,11 +689,11 @@ public class MainPanel extends JPanel implements CustomPlugin {
             }
         }
     }
-    private class DownloadOBRProcess extends SwingWorker {
+    private class DownloadOBRProcess extends SwingWorkerPM {
 
         @Override
         protected Object doInBackground() throws Exception {
-            repositoryAdminTrackerCustomizer.refresh();
+            repositoryAdminTrackerCustomizer.refresh(getProgressMonitor());
             return null;
         }
 

--- a/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/MainPanel.java
+++ b/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/MainPanel.java
@@ -83,7 +83,7 @@ import javax.swing.text.StyleConstants;
 
 import org.orbisgis.omanager.plugin.api.RepositoryPluginHandler;
 
-import org.orbisgis.omanager.plugin.impl.DownloadOBRProcess;
+import org.orbisgis.omanager.plugin.api.DownloadOBRProcess;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.orbisgis.omanager.plugin.api.CustomPlugin;

--- a/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/MainPluginPanel.java
+++ b/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/MainPluginPanel.java
@@ -36,8 +36,8 @@
  */
 package org.orbisgis.omanager.ui;
 
-import org.orbisgis.frameworkapi.CoreWorkspace;
 import org.orbisgis.omanager.plugin.api.CustomPlugin;
+import org.orbisgis.omanager.plugin.api.RepositoryPluginHandler;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.*;
 
@@ -57,6 +57,20 @@ public class MainPluginPanel extends MainPanel {
     @Activate
     public void activate(BundleContext bc) {
         initialize(bc);
+    }
+
+    @Deactivate
+    public void deactivate(BundleContext bc) {
+        dispose();
+    }
+
+    @Reference
+    public void setRepositoryPluginHandler(RepositoryPluginHandler pluginHandler) {
+        this.remotePlugins = pluginHandler;
+    }
+
+    public void unsetRepositoryPluginHandler(RepositoryPluginHandler pluginHandler) {
+        this.remotePlugins = null;
     }
 
     @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)

--- a/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/MainPluginPanel.java
+++ b/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/MainPluginPanel.java
@@ -66,12 +66,4 @@ public class MainPluginPanel extends MainPanel {
 
     public void unsetExecutorService(ExecutorService executorService) {
     }
-
-    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
-    public void setCoreWorkspace(CoreWorkspace coreWorkspace) {
-        super.setCoreWorkspace(coreWorkspace);
-    }
-
-    public void unsetCoreWorkspace(CoreWorkspace coreWorkspace) {
-    }
 }

--- a/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/MainSystemPanel.java
+++ b/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/MainSystemPanel.java
@@ -67,11 +67,4 @@ public class MainSystemPanel extends MainPanel {
     public void unsetExecutorService(ExecutorService executorService) {
     }
 
-    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
-    public void setCoreWorkspace(CoreWorkspace coreWorkspace) {
-        super.setCoreWorkspace(coreWorkspace);
-    }
-
-    public void unsetCoreWorkspace(CoreWorkspace coreWorkspace) {
-    }
 }

--- a/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/MainSystemPanel.java
+++ b/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/MainSystemPanel.java
@@ -36,8 +36,8 @@
  */
 package org.orbisgis.omanager.ui;
 
-import org.orbisgis.frameworkapi.CoreWorkspace;
 import org.orbisgis.omanager.plugin.api.CustomPlugin;
+import org.orbisgis.omanager.plugin.api.RepositoryPluginHandler;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.*;
 
@@ -58,6 +58,21 @@ public class MainSystemPanel extends MainPanel {
     public void activate(BundleContext bc) {
         initialize(bc);
     }
+
+    @Deactivate
+    public void deactivate(BundleContext bc) {
+        dispose();
+    }
+
+    @Reference
+    public void setRepositoryPluginHandler(RepositoryPluginHandler pluginHandler) {
+        this.remotePlugins = pluginHandler;
+    }
+
+    public void unsetRepositoryPluginHandler(RepositoryPluginHandler pluginHandler) {
+        this.remotePlugins = null;
+    }
+
 
     @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
     public void setExecutorService(ExecutorService executorService) {

--- a/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/RepositoryAdminTracker.java
+++ b/bundles/orbisgis-omanager/src/main/java/org/orbisgis/omanager/ui/RepositoryAdminTracker.java
@@ -198,6 +198,9 @@ public class RepositoryAdminTracker implements ServiceTrackerCustomizer<Reposito
                     }
                 }
             }
+            if(propertyChangeSupport.hasListeners(PROP_RESOURCES)) {
+                propertyChangeSupport.firePropertyChange(PROP_RESOURCES, new HashSet<Resource>(), getResources());
+            }
         }
     }
     private boolean isRepositoryAdminAvailable() {


### PR DESCRIPTION
In the plugin manager, the remote list of plugins now display only the compatible plugins (can be installed and resolved dependency)

The list of plugins are now downloaded only when the user first open the plugin manager.

Change the radio button text "Available" to "Compatible"

Checking dependencies take time, so a progress information is displayed.