### PR TITLE
Add various utilities.

### DIFF
--- a/common-utils/src/main/groovy/org/orbisgis/common_utils/ResultSetUtils.groovy
+++ b/common-utils/src/main/groovy/org/orbisgis/common_utils/ResultSetUtils.groovy
@@ -1,0 +1,50 @@
+/*
+ * Bundle common-utils is part of the OrbisGIS platform
+ *
+ * OrbisGIS is a java GIS application dedicated to research in GIScience.
+ * OrbisGIS is developed by the GIS group of the DECIDE team of the
+ * Lab-STICC CNRS laboratory, see <http://www.lab-sticc.fr/>.
+ *
+ * The GIS group of the DECIDE team is located at :
+ *
+ * Laboratoire Lab-STICC – CNRS UMR 6285
+ * Equipe DECIDE
+ * UNIVERSITÉ DE BRETAGNE-SUD
+ * Institut Universitaire de Technologie de Vannes
+ * 8, Rue Montaigne - BP 561 56017 Vannes Cedex
+ *
+ * OSM is distributed under LGPL 3 license.
+ *
+ * Copyright (C) 2020 CNRS (Lab-STICC UMR CNRS 6285)
+ *
+ *
+ * OSM is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * OSM is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * OSM. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
+package org.orbisgis.common_utils
+
+import java.sql.ResultSet
+
+/**
+ * Utility script used as extension module adding methods to {@link ResultSet} class.
+ *
+ * @author Erwan Bocher (CNRS)
+ * @author Sylvain PALOMINOS (UBS chaire GEOTERA 2020)
+ */
+
+static void propertyMissing(ResultSet rs, String name) {
+    rs.getObject(name)
+}

--- a/common-utils/src/main/resources/META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule
+++ b/common-utils/src/main/resources/META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule
@@ -1,5 +1,6 @@
 moduleName=OrbisGIS Groovy commons extension
 moduleVersion=1.0
 extensionClasses=org.orbisgis.common_utils.StringUtils, \
-  org.orbisgis.common_utils.ConnectionUtils
+  org.orbisgis.common_utils.ConnectionUtils, \
+  org.orbisgis.common_utils.ResultSetUtils
 staticExtensionClasses=org.orbisgis.common_utils.ScriptUtilities

--- a/datastore/utils/pom.xml
+++ b/datastore/utils/pom.xml
@@ -33,6 +33,10 @@
             <artifactId>groovy</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-sql</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
@@ -64,6 +68,12 @@
             <groupId>org.geotools</groupId>
             <artifactId>gt-shapefile</artifactId>
             <version>${geotools.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.h2gis</groupId>
+            <artifactId>h2gis-geotools</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/datastore/utils/src/main/groovy/org/orbisgis/datastore/utils/DataStoreFinderUtils.groovy
+++ b/datastore/utils/src/main/groovy/org/orbisgis/datastore/utils/DataStoreFinderUtils.groovy
@@ -1,0 +1,54 @@
+/*
+ * Bundle datastore/utils is part of the OrbisGIS platform
+ *
+ * OrbisGIS is a java GIS application dedicated to research in GIScience.
+ * OrbisGIS is developed by the GIS group of the DECIDE team of the
+ * Lab-STICC CNRS laboratory, see <http://www.lab-sticc.fr/>.
+ *
+ * The GIS group of the DECIDE team is located at :
+ *
+ * Laboratoire Lab-STICC – CNRS UMR 6285
+ * Equipe DECIDE
+ * UNIVERSITÉ DE BRETAGNE-SUD
+ * Institut Universitaire de Technologie de Vannes
+ * 8, Rue Montaigne - BP 561 56017 Vannes Cedex
+ *
+ * OSM is distributed under LGPL 3 license.
+ *
+ * Copyright (C) 2020 CNRS (Lab-STICC UMR CNRS 6285)
+ *
+ *
+ * OSM is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * OSM is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * OSM. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
+package org.orbisgis.datastore.utils
+
+import org.geotools.data.DataStore
+import org.geotools.data.DataStoreFinder
+
+
+/**
+ * Utility script used as extension module adding methods to {@link org.geotools.data.DataStoreFinder} class.
+ *
+ * @author Erwan Bocher (CNRS 2020)
+ * @author Sylvain PALOMINOS (UBS chaire GEOTERA 2020)
+ */
+
+static DataStore getDataStore(DataStoreFinder finder, LinkedHashMap map) {
+    def tmp = [:]
+    map.each {tmp.put(it.key, it.value in GString ? it.value.toString() : it.value)}
+    return DataStoreFinder.getDataStore((Map)tmp)
+}

--- a/datastore/utils/src/main/groovy/org/orbisgis/datastore/utils/DataStoreUtils.groovy
+++ b/datastore/utils/src/main/groovy/org/orbisgis/datastore/utils/DataStoreUtils.groovy
@@ -1,0 +1,57 @@
+/*
+ * Bundle datastore/utils is part of the OrbisGIS platform
+ *
+ * OrbisGIS is a java GIS application dedicated to research in GIScience.
+ * OrbisGIS is developed by the GIS group of the DECIDE team of the
+ * Lab-STICC CNRS laboratory, see <http://www.lab-sticc.fr/>.
+ *
+ * The GIS group of the DECIDE team is located at :
+ *
+ * Laboratoire Lab-STICC – CNRS UMR 6285
+ * Equipe DECIDE
+ * UNIVERSITÉ DE BRETAGNE-SUD
+ * Institut Universitaire de Technologie de Vannes
+ * 8, Rue Montaigne - BP 561 56017 Vannes Cedex
+ *
+ * OSM is distributed under LGPL 3 license.
+ *
+ * Copyright (C) 2020 CNRS (Lab-STICC UMR CNRS 6285)
+ *
+ *
+ * OSM is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * OSM is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * OSM. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
+package org.orbisgis.datastore.utils
+
+import org.geotools.data.DataStore
+
+import org.geotools.data.simple.SimpleFeatureSource
+/**
+ * Utility script used as extension module adding methods to {@link DataStore} class.
+ *
+ * @author Erwan Bocher (CNRS 2020)
+ * @author Sylvain PALOMINOS (UBS chaire GEOTERA 2020)
+ */
+
+/**
+ * Method called when the asked property is missing and returns the SimpleFeatureSource corresponding to the given name.
+ *
+ * @param ds DataStore to use.
+ * @param name Name of the property/SimpleFeatureSource to get.
+ */
+static SimpleFeatureSource propertyMissing(DataStore ds, String name) {
+    return ds.getFeatureSource(name)
+}

--- a/datastore/utils/src/main/resources/META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule
+++ b/datastore/utils/src/main/resources/META-INF/groovy/org.codehaus.groovy.runtime.ExtensionModule
@@ -1,4 +1,5 @@
 moduleName=OrbisGIS Groovy commons extension
 moduleVersion=1.0
-extensionClasses=org.orbisgis.datastore.utils.JDBCDataStoreUtils
-staticExtensionClasses=
+extensionClasses=org.orbisgis.datastore.utils.JDBCDataStoreUtils, \
+  org.orbisgis.datastore.utils.DataStoreUtils
+staticExtensionClasses=org.orbisgis.datastore.utils.DataStoreFinderUtils

--- a/datastore/utils/src/test/groovy/org/orbisgis/datastore/utils/DataStoreUtilsTest.groovy
+++ b/datastore/utils/src/test/groovy/org/orbisgis/datastore/utils/DataStoreUtilsTest.groovy
@@ -1,0 +1,61 @@
+/*
+ * Bundle datastore/utils is part of the OrbisGIS platform
+ *
+ * OrbisGIS is a java GIS application dedicated to research in GIScience.
+ * OrbisGIS is developed by the GIS group of the DECIDE team of the
+ * Lab-STICC CNRS laboratory, see <http://www.lab-sticc.fr/>.
+ *
+ * The GIS group of the DECIDE team is located at :
+ *
+ * Laboratoire Lab-STICC – CNRS UMR 6285
+ * Equipe DECIDE
+ * UNIVERSITÉ DE BRETAGNE-SUD
+ * Institut Universitaire de Technologie de Vannes
+ * 8, Rue Montaigne - BP 561 56017 Vannes Cedex
+ *
+ * OSM is distributed under LGPL 3 license.
+ *
+ * Copyright (C) 2020 CNRS (Lab-STICC UMR CNRS 6285)
+ *
+ *
+ * OSM is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * OSM is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * OSM. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
+package org.orbisgis.datastore.utils
+
+import org.geotools.data.Query
+import org.geotools.data.shapefile.ShapefileDataStore
+import org.junit.jupiter.api.Test
+
+/**
+ * Test class dedicated to {@link org.orbisgis.datastore.utils.DataStoreUtils}.
+ *
+ * @author Erwan Bocher (CNRS 2020)
+ * @author Sylvain PALOMINOS (UBS chaire GEOTERA 2020)
+ */
+class DataStoreUtilsTest {
+
+    @Test
+    void missingPropertyTest() {
+        def name = "landcover2000.shp"
+        assert this.class.getResource(name)
+        def shapefile = new ShapefileDataStore(this.class.getResource(name))
+        assert shapefile
+        def contents = shapefile.landcover2000
+        assert contents
+        assert 1234 == contents.getCount( Query.ALL )
+    }
+}


### PR DESCRIPTION
Add a `ResultSetUtils` which add the methods `missingProperty(String)` which is mapped to the `getObject(String)` method.
Add a `getDataStore(DataSToreFinder, LinkedHashMap)` to `DataStoreFinder` in order to support `GString`.
Add `query(...)` methods to `JDBCDataStore` in order to allow to manipulate it like Groovy `Sql` object (more methods will be coming).