### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ before_install:
 # Do not install anything so that we can use our custom script. Instead, just
 # return true.
 #install: true
-install: travis_retry mvn install -DskipTests -B
+install: mvn install -DskipTests -B
 script: mvn test -B -P no-dist
 #script: "./travis-build.sh"
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION

Does travis_retry really solve the build issues? According to the data in paper [An empirical study of the long duration of continuous integration builds](https://dl.acm.org/doi/10.1007/s10664-019-09695-9), travis_retry can only solve 3% of the build failures. And it may cause unstable build and increase build time.

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
